### PR TITLE
feat: Migrate API to MySQL 8 and update Docker Compose

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,5 +1,5 @@
 FROM ruby:3.4-bookworm
 RUN apt-get update && apt-get install -y \
-    sqlite3
+    default-libmysqlclient-dev
 
 WORKDIR /app

--- a/api/Gemfile
+++ b/api/Gemfile
@@ -15,7 +15,7 @@ gem "nanoid", "~> 2.0"
 
 gem "activerecord", "~> 8.0"
 
-gem "sqlite3", "~> 2.6"
+gem "mysql2", "~> 0.5"
 
 gem "rerun", "~> 0.14.0"
 

--- a/api/db/connection.rb
+++ b/api/db/connection.rb
@@ -5,8 +5,12 @@ module DB
   class Connection
     def self.establish
       ActiveRecord::Base.establish_connection(
-        adapter: "sqlite3",
-        database: Envs::DB_PATH
+        adapter: "mysql2",
+        host: ENV['MYSQL_HOST'],
+        port: ENV['MYSQL_PORT'] || 3306,
+        username: ENV['MYSQL_USER'],
+        password: ENV['MYSQL_PASSWORD'],
+        database: ENV['MYSQL_DATABASE']
       )
     end
   end

--- a/api/scripts/create_database.rb
+++ b/api/scripts/create_database.rb
@@ -5,7 +5,7 @@ require "bundler/inline"
 gemfile do
   source "https://rubygems.org"
   gem "activerecord"
-  gem "sqlite3"
+  gem "mysql2"
 end
 require "active_record"
 

--- a/compose-dev.yml
+++ b/compose-dev.yml
@@ -26,11 +26,18 @@ services:
       ]
     volumes:
       - ./api:/app
-      - ./db:/var/finascope/db
+      # - ./db:/var/finascope/db # Removed for MySQL
       - bundle_cache:/var/bundle_cache
     environment:
-      - FS_SQLITE_FILE=/var/finascope/db/finascope.sqlite3
+      # - FS_SQLITE_FILE=/var/finascope/db/finascope.sqlite3 # Removed for MySQL
       - BUNDLE_PATH=/var/bundle_cache
+      - MYSQL_HOST: db
+      - MYSQL_PORT: 3306
+      - MYSQL_USER: finascope_user
+      - MYSQL_PASSWORD: finascope_password
+      - MYSQL_DATABASE: finascope_db
+    depends_on: # Added for clarity, db service is in compose.yml
+      - db
   front-dev:
     container_name: front
     environment:

--- a/compose.yml
+++ b/compose.yml
@@ -13,12 +13,33 @@ services:
       ]
     volumes:
       - ./api:/app
-      - ./db:/var/finascope/db
       - bundle_cache:/var/bundle_cache
     environment:
-      - FS_SQLITE_FILE=/var/finascope/db/finascope.sqlite3
       - BUNDLE_PATH=/var/bundle_cache
+      - MYSQL_HOST: db
+      - MYSQL_PORT: 3306
+      - MYSQL_USER: finascope_user
+      - MYSQL_PASSWORD: finascope_password
+      - MYSQL_DATABASE: finascope_db
     ports:
       - "9292:9292"
+    depends_on:
+      - db
+
+  db:
+    image: mysql:8
+    container_name: mysql
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: example_root_password
+      MYSQL_DATABASE: finascope_db
+      MYSQL_USER: finascope_user
+      MYSQL_PASSWORD: finascope_password
+    volumes:
+      - mysql_data:/var/lib/mysql
+    ports:
+      - "3306:3306"
+
 volumes:
   bundle_cache:
+  mysql_data:


### PR DESCRIPTION
This commit migrates the API from SQLite to MySQL 8.

Changes include:
- Updated Gemfile to use `mysql2` adapter.
- Modified database connection settings in `api/db/connection.rb` to support MySQL.
- Updated `api/scripts/create_database.rb` to use `mysql2` gem.
- Reconfigured `compose.yml` and `compose-dev.yml`:
    - Added a MySQL 8 service (`db`).
    - Updated the `api` service to connect to the new MySQL service using environment variables.
    - Removed SQLite configurations and volumes.
    - Added a persistent volume for MySQL data.
- Updated `api/Dockerfile` to install MySQL client libraries.

I was unable to test the full Docker Compose setup due to limitations in my execution environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - データベースをSQLiteからMySQLに切り替え、MySQL用の接続設定や環境変数を追加しました。
  - Docker ComposeにMySQLコンテナサービスを追加し、永続化ボリュームを設定しました。

- **その他**
  - 開発用構成ファイルをMySQL対応に更新し、不要となったSQLite関連の設定を削除しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->