### PR TITLE
fix: invoice record編集ダイアログが閉じない不具合を修正

### DIFF
--- a/front/src/routes/invoice-records/row-menu.svelte
+++ b/front/src/routes/invoice-records/row-menu.svelte
@@ -113,10 +113,9 @@
   <Popover.Trigger><Ellipsis class="mx-2" /></Popover.Trigger>
   <Popover.Content class="w-fit">
     <div class="flex flex-col gap-1">
-      <Dialog.Root open={editDialogOpen}>
+      <Dialog.Root bind:open={editDialogOpen}>
         <Dialog.Trigger
           class="{buttonVariants({ variant: 'ghost' })} w-full justify-stretch px-2 py-2"
-          onclick={() => (editDialogOpen = true)}
         >
           <span> Edit </span>
         </Dialog.Trigger>
@@ -146,10 +145,9 @@
           </div>
         </Dialog.Content>
       </Dialog.Root>
-      <Dialog.Root open={deleteDialogOpen}>
+      <Dialog.Root bind:open={deleteDialogOpen}>
         <Dialog.Trigger
           class="{buttonVariants({ variant: 'ghost' })} w-full justify-stretch px-2 py-2"
-          onclick={() => (deleteDialogOpen = true)}
         >
           <span>Delete</span>
         </Dialog.Trigger>


### PR DESCRIPTION
## 概要
- invoice-recordの編集ダイアログで、更新が成功してもポップアップが閉じない不具合を修正
- `Dialog.Root`の`open`プロパティを`bind:open`に変更して双方向バインディングを有効化

## 変更内容
- `front/src/routes/invoice-records/row-menu.svelte`で`open={editDialogOpen}`を`bind:open={editDialogOpen}`に変更
- `open={deleteDialogOpen}`も同様に`bind:open={deleteDialogOpen}`に変更
- 不要な`onclick`ハンドラーを削除

## 修正理由
従来の実装では`open={dialogOpen}`による一方向バインディングのため、`Dialog.Trigger`がクリックされてもダイアログの状態が自動更新されませんでした。`bind:open`を使用することで、Dialogコンポーネントが内部的に状態を管理し、編集完了後の`editDialogClose()`呼び出しで正しくダイアログが閉じるようになります。

## テスト手順
1. invoice-recordsページでレコードの編集ボタンをクリック
2. 編集フォームで値を変更して更新ボタンをクリック
3. 更新が成功した後、ダイアログが自動的に閉じることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)