### PR TITLE
feat: add shared MySQL setup for multi-worktree development

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,13 +14,16 @@ Finascope is a personal finance management application with a microservices arch
 
 ### Local Development (Recommended)
 ```bash
-# Start full development environment
+# First time: Start shared MySQL database
+docker compose -f compose-dev-mysql.yml up -d
+
+# Start full development environment (any worktree)
 docker compose -f compose-dev.yml up
 
 # Access points:
 # - Frontend: http://localhost:8080 (via nginx)
 # - API: http://localhost:9292 (direct)
-# - MySQL: localhost:3306
+# - MySQL: localhost:3306 (shared across all worktrees)
 ```
 
 ### Individual Services

--- a/compose-dev-mysql.yml
+++ b/compose-dev-mysql.yml
@@ -1,0 +1,19 @@
+services:
+  mysql:
+    container_name: finascope-mysql
+    image: mysql:8.0
+    environment:
+      MYSQL_ROOT_PASSWORD: example
+    user: 1000:1000
+    volumes:
+      - finascope_mysql_data:/var/lib/mysql
+      - ./mysql/init.d:/docker-entrypoint-initdb.d
+    networks:
+      - finascope-net
+
+networks:
+  finascope-net:
+    name: finascope-net
+
+volumes:
+  finascope_mysql_data:

--- a/compose-dev.yml
+++ b/compose-dev.yml
@@ -29,11 +29,13 @@ services:
       - bundle_cache:/var/bundle_cache
     environment:
       - BUNDLE_PATH=/var/bundle_cache
-      - DB_HOST=mysql
+      - DB_HOST=finascope-mysql
       - DB_PORT=3306
       - DB_USER=finascope_app
       - DB_PASSWORD=finascope_app_password
       - DB_NAME=finascope
+    networks:
+      - finascope-net
   front-dev:
     container_name: front
     environment:
@@ -51,15 +53,12 @@ services:
     volumes:
       - ./front:/app
       - /app/node_modules
-  mysql:
-    container_name: mysql
-    image: mysql:8.0
-    environment:
-      MYSQL_ROOT_PASSWORD: example
-    user: 1000:1000
-    volumes:
-      - ./db/mysql:/var/lib/mysql
-      - ./mysql/init.d:/docker-entrypoint-initdb.d
-
+    networks:
+      - finascope-net
 volumes:
   bundle_cache:
+
+networks:
+  finascope-net:
+    external: true
+    name: finascope-net


### PR DESCRIPTION
## Summary
- どのworktreeからdocker composeを実行しても同じMySQLデータベースに接続できるようにした
- 開発効率向上のため、サンプルデータを毎回入れ直す必要がなくなった

## Changes
- **compose-dev-mysql.yml**: MySQL専用のcompose設定を新規作成
- **compose-dev.yml**: mysqlサービスを削除し、external networkで接続するよう修正
- **CLAUDE.md**: 新しい開発手順を追記

## Test plan
- [ ] `docker compose -f compose-dev-mysql.yml up -d` でMySQLを起動
- [ ] プロジェクトルートで `docker compose -f compose-dev.yml up` が動作する
- [ ] claude-workspaceで `docker compose -f compose-dev.yml up` が同じMySQLに接続する
- [ ] 両方のworktreeで同じデータベースのデータが見える

🤖 Generated with [Claude Code](https://claude.ai/code)