### PR TITLE
Include response structure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,4 +40,5 @@ update-openapi:
 	docker run -it --rm -v `pwd`:/app ruby:3.4 bash -c "cd /app/api && bundle i && rake openapi:generate"
 
 openapi-viewer:
+	@echo "Access to http://localhost:9001 to view the OpenAPI documentation\n\n"
 	docker run -p 9001:8080 -v `pwd`/docs/openapi_swagger_doc.json:/openapi.json -e SWAGGER_JSON=/openapi.json docker.swagger.io/swaggerapi/swagger-ui

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,10 @@
 # Finascope開発用Makefile
 
-.PHONY: help dev dev-mysql logs schema-update console api-shell db-shell clean
+.PHONY: help dev dev-mysql logs schema-update console api-shell db-shell clean update-openapi openapi-viewer
 
 # デフォルトターゲット
 help:
-	@echo "Finascope開発用コマンド:"
-	@echo "  make dev           開発環境を起動 (compose-dev.yml)"
-	@echo "  make dev-mysql     共有MySQL環境を起動 (compose-dev-mysql.yml)"
-	@echo "  make logs          コンテナログを表示"
-	@echo "  make schema-update DBスキーマを更新"
-	@echo "  make console       APIコンソールを起動"
-	@echo "  make api-shell     APIコンテナのシェルに接続"
-	@echo "  make db-shell      MySQLシェルに接続"
-	@echo "  make clean         開発環境を停止・削除"
+	@cat Makefile | grep '^[a-zA-Z_-]\+:' | sed 's/://g' | awk '{printf " - %s\n", $$1}'
 
 # 開発環境管理
 dev:
@@ -42,3 +34,10 @@ api-shell:
 
 db-shell:
 	docker compose -f compose-dev.yml exec mysql mysql -u finascope -pfinascope finascope_dev
+
+# OpenAPI
+update-openapi:
+	docker run -it --rm -v `pwd`:/app ruby:3.4 bash -c "cd /app/api && bundle i && rake openapi:generate"
+
+openapi-viewer:
+	docker run -p 9001:8080 -v `pwd`/docs/openapi_swagger_doc.json:/openapi.json -e SWAGGER_JSON=/openapi.json docker.swagger.io/swaggerapi/swagger-ui

--- a/api/app/api/root.rb
+++ b/api/app/api/root.rb
@@ -3,6 +3,7 @@
 require "grape"
 require "lib/firebase"
 require "grape-swagger"
+require "grape-swagger-entity"
 require_relative "./v1/root"
 
 module API
@@ -46,6 +47,15 @@ module API
   class Documentation < Grape::API
     format :json
     mount API::Root
-    add_swagger_documentation
+    add_swagger_documentation \
+      models: [
+        API::Entities::Categories::Category,
+        API::Entities::CommonResponse,
+        API::Entities::InvoiceRecords::InvoiceRecord,
+        API::Entities::InvoiceRecords::WithdrawalRecordsAggregation,
+        API::Entities::PaymentMethods::PaymentMethod,
+        API::Entities::Records::Record,
+        API::Entities::View::CategoryAggregation
+      ]
   end
 end

--- a/api/app/api/v1/categories.rb
+++ b/api/app/api/v1/categories.rb
@@ -12,6 +12,8 @@ module API
   module V1
     class Categories < Grape::API
       resource :categories do
+        desc "Get Categories",
+          success: { model: API::Entities::Categories::Category, is_array: true, as: :categories }
         get do
           uid = request_userdata[:uid]
           categories_service = Service::Categories.new(uid:)
@@ -19,11 +21,12 @@ module API
           present categories, with: API::Entities::Categories::Category, root: :categories
         end
 
+        desc "Create a Category",
+          entity: API::Entities::CommonResponse
+        params do
+          requires :label, type: String, desc: 'Category label'
+        end
         post do
-          params do
-            requires :label, type: String, desc: 'Category label'
-          end
-
           uid = request_userdata[:uid]
           categories_service = Service::Categories.new(uid:)
           category = categories_service.create(label: params[:label])
@@ -38,12 +41,13 @@ module API
           present resp, with: API::Entities::CommonResponse
         end
 
+        desc "Update a Category",
+          entity: API::Entities::CommonResponse
+        params do
+          requires :id, type: String, desc: 'Category ID'
+          requires :label, type: String, desc: 'Category label'
+        end
         put ':id' do
-          params do
-            requires :id, type: String, desc: 'PaymentMethod ID'
-            requires :label, type: String, desc: 'PaymentMethod label'
-          end
-
           uid = request_userdata[:uid]
           categories_service = Service::Categories.new(uid:)
           category = categories_service.update(

--- a/api/app/api/v1/invoice_records.rb
+++ b/api/app/api/v1/invoice_records.rb
@@ -12,6 +12,8 @@ module API
   module V1
     class InvoiceRecords < Grape::API
       resource :invoice_records do
+        desc "Get Invoice Records",
+          success: { model: API::Entities::InvoiceRecords::InvoiceRecord, is_array: true, as: :records }
         get do
           if params[:year] && params[:month]
             year = params[:year].to_i
@@ -39,13 +41,15 @@ module API
           present res, with: API::Entities::InvoiceRecords::InvoiceRecord, root: :records
         end
 
+        desc "Create an Invoice Record",
+          entity: API::Entities::CommonResponse
+        params do
+          requires :amount, type: Integer, desc: 'Invoice record amount'
+          requires :state_id, type: Integer, desc: 'Invoice record state ID'
+          requires :withdrawal_date, type: String, desc: 'Withdrawal date in ISO8601 format'
+          requires :payment_method_id, type: String, desc: 'Payment method ID'
+        end
         post do
-          params do
-            require :amount, type: Integer, desc: 'Invoice record amount'
-            require :state_id, type: Integer, desc: 'Invoice record state ID'
-            require :withdrawal_date, type: String, desc: 'Withdrawal date in ISO8601 format'
-            require :payment_method_id, type: String, desc: 'Payment method ID'
-          end
           puts params.inspect
 
           uid = request_userdata[:uid]
@@ -67,14 +71,15 @@ module API
           present resp, with: API::Entities::CommonResponse
         end
 
+        desc "Update an Invoice Record",
+          entity: API::Entities::CommonResponse
+        params do
+          requires :id, type: Integer, desc: 'Invoice record ID'
+          requires :amount, type: Integer, desc: 'Invoice record amount'
+          requires :state_id, type: Integer, desc: 'Invoice record state ID'
+          requires :withdrawal_date, type: String, desc: 'Withdrawal date in ISO8601 format'
+        end
         put ':id' do
-          params do
-            require :id, type: Integer, desc: 'Invoice record ID'
-            require :amount, type: Integer, desc: 'Invoice record amount'
-            require :state_id, type: Integer, desc: 'Invoice record state ID'
-            require :withdrawal_date, type: String, desc: 'Withdrawal date in ISO8601 format'
-          end
-
           uid = request_userdata[:uid]
           invoice_records_service = Service::InvoiceRecords.new(uid:)
           record = invoice_records_service.update(
@@ -97,11 +102,12 @@ module API
           present resp, with: API::Entities::CommonResponse
         end
 
+        desc "Delete an Invoice Record",
+          entity: API::Entities::CommonResponse
+        params do
+          requires :id, type: String, desc: 'Invoice record ID'
+        end
         delete ':id' do
-          params do
-            requires :id, type: String, desc: 'Invoice record ID'
-          end
-
           uid = request_userdata[:uid]
           Service::InvoiceRecords.new(uid:).delete( # NOTE: ダメなら exception が飛んでくる
             id: params[:id]
@@ -112,6 +118,8 @@ module API
           present resp, with: API::Entities::CommonResponse
         end
 
+        desc "Get Withdrawal Records Aggregation",
+          success: { model: API::Entities::InvoiceRecords::WithdrawalRecordsAggregation, as: :aggregation }
         params do
           requires :year, type: Integer, desc: 'Target year'
           requires :month, type: Integer, desc: 'Target month'

--- a/api/app/api/v1/payment_methods.rb
+++ b/api/app/api/v1/payment_methods.rb
@@ -12,6 +12,8 @@ module API
   module V1
     class PaymentMethods < Grape::API
       resource :payment_methods do
+        desc "Get Payment Methods",
+          success: { model: API::Entities::PaymentMethods::PaymentMethod, is_array: true, as: :payment_methods }
         get do
           uid = request_userdata[:uid]
           payment_methods_service = Service::PaymentMethods.new(uid:)
@@ -21,13 +23,14 @@ module API
                   root: :payment_methods
         end
 
+        desc "Create a Payment Method",
+          entity: API::Entities::CommonResponse
+        params do
+          requires :label, type: String, desc: 'PaymentMethod label'
+          requires :withdrawal_day_of_month, type: Integer, desc: 'Withdrawal day of month'
+          optional :closing_day_of_month, type: Integer, desc: 'Closing day of month', default: 0
+        end
         post do
-          params do
-            requires :label, type: String, desc: 'PaymentMethod label'
-            requires :withdrawal_day_of_month, type: Integer, desc: 'Withdrawal day of month'
-            optional :closing_day_of_month, type: Integer, desc: 'Closing day of month', default: 0
-          end
-
           uid = request_userdata[:uid]
           payment_methods_service = Service::PaymentMethods.new(uid:)
           payment_method = payment_methods_service.create(
@@ -46,14 +49,15 @@ module API
           present resp, with: API::Entities::CommonResponse
         end
 
+        desc "Update a Payment Method",
+          entity: API::Entities::CommonResponse
+        params do
+          requires :id, type: String, desc: 'PaymentMethod ID'
+          requires :label, type: String, desc: 'PaymentMethod label'
+          requires :withdrawal_day_of_month, type: Integer, desc: 'Withdrawal day of month'
+          optional :closing_day_of_month, type: Integer, desc: 'Closing day of month'
+        end
         put ':id' do
-          params do
-            requires :id, type: String, desc: 'PaymentMethod ID'
-            requires :label, type: String, desc: 'PaymentMethod label'
-            requires :withdrawal_day_of_month, type: Integer, desc: 'Withdrawal day of month'
-            optional :closing_day_of_month, type: Integer, desc: 'Closing day of month'
-          end
-
           uid = request_userdata[:uid]
           payment_methods_service = Service::PaymentMethods.new(uid:)
           payment_method = payment_methods_service.update(

--- a/api/app/api/v1/records.rb
+++ b/api/app/api/v1/records.rb
@@ -17,6 +17,8 @@ module API
       format :json
 
       resource :records do
+        desc "Get Records",
+          success: { model: API::Entities::Records::Record, is_array: true, as: :records }
         get do
           page = params[:page].to_i if params[:page]
           begin_date = Date.parse(params[:begin_date])&.beginning_of_day if params[:begin_date]
@@ -28,18 +30,19 @@ module API
           present records, with: API::Entities::Records::Record, root: :records
         end
 
+        desc "Create a Record",
+          entity: API::Entities::CommonResponse
+        params do
+          requires :title, type: String, desc: 'Record title'
+          requires :type_id, type: Integer, desc: 'Record type ID'
+          requires :state_id, type: Integer, desc: 'Record state ID'
+          requires :description, type: String, desc: 'Record description'
+          requires :amount, type: Integer, desc: 'Record amount'
+          requires :category_id, type: String, desc: 'Record category ID'
+          requires :date, type: String, desc: 'Record date in ISO8601 format'
+          requires :payment_method_id, type: String, desc: 'Payment method ID'
+        end
         post do
-          params do
-            requires :title, type: String, desc: 'Record title'
-            requires :type_id, type: Integer, desc: 'Record type ID'
-            requires :state_id, type: Integer, desc: 'Record state ID'
-            requires :description, type: String, desc: 'Record description'
-            requires :amount, type: Integer, desc: 'Record amount'
-            requires :category_id, type: String, desc: 'Record category ID'
-            requires :date, type: String, desc: 'Record date in ISO8601 format'
-            require :payment_method_id, type: String, desc: 'Payment method ID'
-          end
-
           uid = request_userdata[:uid]
           finance_records_service = Service::FinanceRecords.new(uid:)
           record = finance_records_service.create(
@@ -64,19 +67,20 @@ module API
           present resp, with: API::Entities::CommonResponse
         end
 
+        desc "Update a Record",
+          entity: API::Entities::CommonResponse
+        params do
+          requires :id, type: String, desc: 'Record ID'
+          requires :title, type: String, desc: 'Record title'
+          requires :type_id, type: Integer, desc: 'Record type ID'
+          requires :state_id, type: Integer, desc: 'Record state ID'
+          requires :description, type: String, desc: 'Record description'
+          requires :amount, type: Integer, desc: 'Record amount'
+          requires :category_id, type: String, desc: 'Record category ID'
+          requires :date, type: String, desc: 'Record date in ISO8601 format'
+          requires :payment_method_id, type: String, desc: 'Payment method ID'
+        end
         put ':id' do
-          params do
-            requires :id, type: String, desc: 'PaymentMethod ID'
-            requires :title, type: String, desc: 'Record title'
-            requires :type_id, type: Integer, desc: 'Record type ID'
-            requires :state_id, type: Integer, desc: 'Record state ID'
-            requires :description, type: String, desc: 'Record description'
-            requires :amount, type: Integer, desc: 'Record amount'
-            requires :category_id, type: String, desc: 'Record category ID'
-            requires :date, type: String, desc: 'Record date in ISO8601 format'
-            require :payment_method_id, type: String, desc: 'Payment method ID'
-          end
-
           uid = request_userdata[:uid]
           finance_records_service = Service::FinanceRecords.new(uid:)
           record = finance_records_service.update(
@@ -103,11 +107,12 @@ module API
           present resp, with: API::Entities::CommonResponse
         end
 
+        desc "Delete a Record",
+          entity: API::Entities::CommonResponse
+        params do
+          requires :id, type: String, desc: 'Record ID'
+        end
         delete ':id' do
-          params do
-            requires :id, type: String, desc: 'PaymentMethod ID'
-          end
-
           uid = request_userdata[:uid]
           finance_records_service = Service::FinanceRecords.new(uid:)
           finance_records_service.delete( # NOTE: ダメなら exception が飛んでくる

--- a/api/app/api/v1/root.rb
+++ b/api/app/api/v1/root.rb
@@ -20,6 +20,7 @@ module API
       mount API::V1::View
 
       resource :healthcheck do
+        desc "Check API Health"
         get do
           { status: 'healthy' }
         end

--- a/api/app/api/v1/view.rb
+++ b/api/app/api/v1/view.rb
@@ -15,12 +15,13 @@ module API
 
       resource :view do
         namespace :categories do
+          desc "Get Category Aggregation",
+            success: { model: API::Entities::View::CategoryAggregation, is_array: true, as: :aggregations }
+          params do
+            optional :begin_date, type: String, desc: 'Start date in YYYY-MM-DD format'
+            optional :end_date, type: String, desc: 'End date in YYYY-MM-DD format'
+          end
           get :aggregation do
-            params do
-              optional :begin_date, type: String, desc: 'Start date in YYYY-MM-DD format'
-              optional :end_date, type: String, desc: 'End date in YYYY-MM-DD format'
-            end
-
             # 期間指定のバリデーション
             if (params[:begin_date].present? && params[:end_date].blank?) ||
                (params[:begin_date].blank? && params[:end_date].present?)

--- a/docs/openapi_swagger_doc.json
+++ b/docs/openapi_swagger_doc.json
@@ -53,12 +53,13 @@
     },
     "/api/v1/healthcheck": {
       "get": {
+        "description": "Check API Health",
         "produces": [
           "application/json"
         ],
         "responses": {
           "200": {
-            "description": "get Healthcheck(s)"
+            "description": "Check API Health"
           }
         },
         "tags": [
@@ -69,12 +70,24 @@
     },
     "/api/v1/records": {
       "get": {
+        "description": "Get Records",
         "produces": [
           "application/json"
         ],
         "responses": {
           "200": {
-            "description": "get Record(s)"
+            "description": "Get Records",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "records": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/API_Entities_Records_Record"
+                  }
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -83,15 +96,29 @@
         "operationId": "getApiV1Records"
       },
       "post": {
+        "description": "Create a Record",
         "produces": [
           "application/json"
         ],
         "consumes": [
           "application/json"
         ],
+        "parameters": [
+          {
+            "name": "postApiV1Records",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/postApiV1Records"
+            }
+          }
+        ],
         "responses": {
           "201": {
-            "description": "created Record"
+            "description": "Create a Record",
+            "schema": {
+              "$ref": "#/definitions/API_Entities_CommonResponse"
+            }
           }
         },
         "tags": [
@@ -102,6 +129,7 @@
     },
     "/api/v1/records/{id}": {
       "put": {
+        "description": "Update a Record",
         "produces": [
           "application/json"
         ],
@@ -112,14 +140,25 @@
           {
             "in": "path",
             "name": "id",
-            "type": "integer",
-            "format": "int32",
+            "description": "Record ID",
+            "type": "string",
             "required": true
+          },
+          {
+            "name": "putApiV1RecordsId",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/putApiV1RecordsId"
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "updated Record"
+            "description": "Update a Record",
+            "schema": {
+              "$ref": "#/definitions/API_Entities_CommonResponse"
+            }
           }
         },
         "tags": [
@@ -128,6 +167,7 @@
         "operationId": "putApiV1RecordsId"
       },
       "delete": {
+        "description": "Delete a Record",
         "produces": [
           "application/json"
         ],
@@ -135,14 +175,17 @@
           {
             "in": "path",
             "name": "id",
-            "type": "integer",
-            "format": "int32",
+            "description": "Record ID",
+            "type": "string",
             "required": true
           }
         ],
         "responses": {
-          "204": {
-            "description": "deleted Record"
+          "200": {
+            "description": "Delete a Record",
+            "schema": {
+              "$ref": "#/definitions/API_Entities_CommonResponse"
+            }
           }
         },
         "tags": [
@@ -153,12 +196,24 @@
     },
     "/api/v1/categories": {
       "get": {
+        "description": "Get Categories",
         "produces": [
           "application/json"
         ],
         "responses": {
           "200": {
-            "description": "get Category(s)"
+            "description": "Get Categories",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "categories": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/API_Entities_Categories_Category"
+                  }
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -167,15 +222,29 @@
         "operationId": "getApiV1Categories"
       },
       "post": {
+        "description": "Create a Category",
         "produces": [
           "application/json"
         ],
         "consumes": [
           "application/json"
         ],
+        "parameters": [
+          {
+            "name": "postApiV1Categories",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/postApiV1Categories"
+            }
+          }
+        ],
         "responses": {
           "201": {
-            "description": "created Category"
+            "description": "Create a Category",
+            "schema": {
+              "$ref": "#/definitions/API_Entities_CommonResponse"
+            }
           }
         },
         "tags": [
@@ -186,6 +255,7 @@
     },
     "/api/v1/categories/{id}": {
       "put": {
+        "description": "Update a Category",
         "produces": [
           "application/json"
         ],
@@ -196,14 +266,25 @@
           {
             "in": "path",
             "name": "id",
-            "type": "integer",
-            "format": "int32",
+            "description": "Category ID",
+            "type": "string",
             "required": true
+          },
+          {
+            "name": "putApiV1CategoriesId",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/putApiV1CategoriesId"
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "updated Category"
+            "description": "Update a Category",
+            "schema": {
+              "$ref": "#/definitions/API_Entities_CommonResponse"
+            }
           }
         },
         "tags": [
@@ -214,12 +295,24 @@
     },
     "/api/v1/payment_methods": {
       "get": {
+        "description": "Get Payment Methods",
         "produces": [
           "application/json"
         ],
         "responses": {
           "200": {
-            "description": "get PaymentMethod(s)"
+            "description": "Get Payment Methods",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "payment_methods": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/API_Entities_PaymentMethods_PaymentMethod"
+                  }
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -228,15 +321,29 @@
         "operationId": "getApiV1PaymentMethods"
       },
       "post": {
+        "description": "Create a Payment Method",
         "produces": [
           "application/json"
         ],
         "consumes": [
           "application/json"
         ],
+        "parameters": [
+          {
+            "name": "postApiV1PaymentMethods",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/postApiV1PaymentMethods"
+            }
+          }
+        ],
         "responses": {
           "201": {
-            "description": "created PaymentMethod"
+            "description": "Create a Payment Method",
+            "schema": {
+              "$ref": "#/definitions/API_Entities_CommonResponse"
+            }
           }
         },
         "tags": [
@@ -247,6 +354,7 @@
     },
     "/api/v1/payment_methods/{id}": {
       "put": {
+        "description": "Update a Payment Method",
         "produces": [
           "application/json"
         ],
@@ -257,14 +365,25 @@
           {
             "in": "path",
             "name": "id",
-            "type": "integer",
-            "format": "int32",
+            "description": "PaymentMethod ID",
+            "type": "string",
             "required": true
+          },
+          {
+            "name": "putApiV1PaymentMethodsId",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/putApiV1PaymentMethodsId"
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "updated PaymentMethod"
+            "description": "Update a Payment Method",
+            "schema": {
+              "$ref": "#/definitions/API_Entities_CommonResponse"
+            }
           }
         },
         "tags": [
@@ -275,12 +394,24 @@
     },
     "/api/v1/invoice_records": {
       "get": {
+        "description": "Get Invoice Records",
         "produces": [
           "application/json"
         ],
         "responses": {
           "200": {
-            "description": "get InvoiceRecord(s)"
+            "description": "Get Invoice Records",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "records": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/API_Entities_InvoiceRecords_InvoiceRecord"
+                  }
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -289,15 +420,29 @@
         "operationId": "getApiV1InvoiceRecords"
       },
       "post": {
+        "description": "Create an Invoice Record",
         "produces": [
           "application/json"
         ],
         "consumes": [
           "application/json"
         ],
+        "parameters": [
+          {
+            "name": "postApiV1InvoiceRecords",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/postApiV1InvoiceRecords"
+            }
+          }
+        ],
         "responses": {
           "201": {
-            "description": "created InvoiceRecord"
+            "description": "Create an Invoice Record",
+            "schema": {
+              "$ref": "#/definitions/API_Entities_CommonResponse"
+            }
           }
         },
         "tags": [
@@ -308,6 +453,7 @@
     },
     "/api/v1/invoice_records/{id}": {
       "put": {
+        "description": "Update an Invoice Record",
         "produces": [
           "application/json"
         ],
@@ -318,14 +464,26 @@
           {
             "in": "path",
             "name": "id",
+            "description": "Invoice record ID",
             "type": "integer",
             "format": "int32",
             "required": true
+          },
+          {
+            "name": "putApiV1InvoiceRecordsId",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/putApiV1InvoiceRecordsId"
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "updated InvoiceRecord"
+            "description": "Update an Invoice Record",
+            "schema": {
+              "$ref": "#/definitions/API_Entities_CommonResponse"
+            }
           }
         },
         "tags": [
@@ -334,6 +492,7 @@
         "operationId": "putApiV1InvoiceRecordsId"
       },
       "delete": {
+        "description": "Delete an Invoice Record",
         "produces": [
           "application/json"
         ],
@@ -341,14 +500,17 @@
           {
             "in": "path",
             "name": "id",
-            "type": "integer",
-            "format": "int32",
+            "description": "Invoice record ID",
+            "type": "string",
             "required": true
           }
         ],
         "responses": {
-          "204": {
-            "description": "deleted InvoiceRecord"
+          "200": {
+            "description": "Delete an Invoice Record",
+            "schema": {
+              "$ref": "#/definitions/API_Entities_CommonResponse"
+            }
           }
         },
         "tags": [
@@ -359,6 +521,7 @@
     },
     "/api/v1/invoice_records/withdrawal_records_aggregation": {
       "get": {
+        "description": "Get Withdrawal Records Aggregation",
         "produces": [
           "application/json"
         ],
@@ -389,7 +552,15 @@
         ],
         "responses": {
           "200": {
-            "description": "get WithdrawalRecordsAggregation(s)"
+            "description": "Get Withdrawal Records Aggregation",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "aggregation": {
+                  "$ref": "#/definitions/API_Entities_InvoiceRecords_WithdrawalRecordsAggregation"
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -400,12 +571,40 @@
     },
     "/api/v1/view/categories/aggregation": {
       "get": {
+        "description": "Get Category Aggregation",
         "produces": [
           "application/json"
         ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "begin_date",
+            "description": "Start date in YYYY-MM-DD format",
+            "type": "string",
+            "required": false
+          },
+          {
+            "in": "query",
+            "name": "end_date",
+            "description": "End date in YYYY-MM-DD format",
+            "type": "string",
+            "required": false
+          }
+        ],
         "responses": {
           "200": {
-            "description": "get Aggregation(s)"
+            "description": "Get Category Aggregation",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "aggregations": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/API_Entities_View_CategoryAggregation"
+                  }
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -413,6 +612,492 @@
         ],
         "operationId": "getApiV1ViewCategoriesAggregation"
       }
+    }
+  },
+  "definitions": {
+    "API_Entities_Categories_Category": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Category ID"
+        },
+        "label": {
+          "type": "string",
+          "description": "Category label"
+        }
+      },
+      "required": [
+        "id",
+        "label"
+      ],
+      "description": "API_Entities_Categories_Category model"
+    },
+    "API_Entities_CommonResponse": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "status",
+        "id"
+      ],
+      "description": "API_Entities_CommonResponse model"
+    },
+    "API_Entities_InvoiceRecords_InvoiceRecord": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "InvoiceRecord ID"
+        },
+        "amount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "InvoiceRecord amount"
+        },
+        "payment_method": {
+          "type": "string",
+          "description": "Payment method used"
+        },
+        "payment_method_id": {
+          "type": "string",
+          "description": "Payment method ID"
+        },
+        "withdrawal_date": {
+          "type": "string",
+          "description": "Withdrawal date. ISO8601"
+        },
+        "state": {
+          "type": "string",
+          "description": "State of the invoice record"
+        },
+        "state_id": {
+          "type": "integer",
+          "format": "int32",
+          "description": "State ID of the invoice record"
+        }
+      },
+      "required": [
+        "id",
+        "amount",
+        "payment_method",
+        "payment_method_id",
+        "withdrawal_date",
+        "state",
+        "state_id"
+      ],
+      "description": "API_Entities_InvoiceRecords_InvoiceRecord model"
+    },
+    "API_Entities_InvoiceRecords_WithdrawalRecordsAggregation": {
+      "type": "object",
+      "properties": {
+        "payment_method_id": {
+          "type": "string",
+          "description": "Payment method ID"
+        },
+        "payment_method": {
+          "type": "string",
+          "description": "Payment method name"
+        },
+        "total_amount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Total amount for this payment method"
+        },
+        "begin_date": {
+          "type": "string",
+          "description": "Aggregation period start date (ISO8601)"
+        },
+        "end_date": {
+          "type": "string",
+          "description": "Aggregation period end date (ISO8601)"
+        },
+        "records": {
+          "$ref": "#/definitions/API_Entities_Records_Record",
+          "description": "Finance records for this payment method"
+        }
+      },
+      "required": [
+        "payment_method_id",
+        "payment_method",
+        "total_amount",
+        "begin_date",
+        "end_date",
+        "records"
+      ],
+      "description": "API_Entities_InvoiceRecords_WithdrawalRecordsAggregation model"
+    },
+    "API_Entities_Records_Record": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Record ID"
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of record"
+        },
+        "title": {
+          "type": "string",
+          "description": "Title of record"
+        },
+        "amount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Amount of record"
+        },
+        "state": {
+          "type": "string",
+          "description": "State of record"
+        },
+        "category": {
+          "type": "string",
+          "description": "Category of record"
+        },
+        "payment_method": {
+          "type": "string",
+          "description": "Payment method used"
+        },
+        "date": {
+          "type": "string",
+          "description": "Date of record"
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of record"
+        },
+        "record_type_id": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Record type ID"
+        },
+        "state_id": {
+          "type": "integer",
+          "format": "int32",
+          "description": "State ID"
+        },
+        "category_id": {
+          "type": "string",
+          "description": "Category ID"
+        },
+        "payment_method_id": {
+          "type": "string",
+          "description": "Payment method ID"
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "title",
+        "amount",
+        "state",
+        "category",
+        "payment_method",
+        "date",
+        "description",
+        "record_type_id",
+        "state_id",
+        "category_id",
+        "payment_method_id"
+      ],
+      "description": "API_Entities_Records_Record model"
+    },
+    "API_Entities_PaymentMethods_PaymentMethod": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "PaymentMethod ID"
+        },
+        "label": {
+          "type": "string",
+          "description": "PaymentMethod label"
+        },
+        "withdrawal_day_of_month": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Withdrawal day of month"
+        },
+        "closing_day_of_month": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Closing day of month"
+        }
+      },
+      "required": [
+        "id",
+        "label",
+        "withdrawal_day_of_month",
+        "closing_day_of_month"
+      ],
+      "description": "API_Entities_PaymentMethods_PaymentMethod model"
+    },
+    "API_Entities_View_CategoryAggregation": {
+      "type": "object",
+      "properties": {
+        "category_id": {
+          "type": "string"
+        },
+        "category": {
+          "type": "string"
+        },
+        "total_amount": {
+          "type": "string"
+        },
+        "record_count": {
+          "type": "string"
+        },
+        "records": {
+          "$ref": "#/definitions/API_Entities_Records_Record"
+        }
+      },
+      "required": [
+        "category_id",
+        "category",
+        "total_amount",
+        "record_count",
+        "records"
+      ],
+      "description": "API_Entities_View_CategoryAggregation model"
+    },
+    "postApiV1Records": {
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string",
+          "description": "Record title"
+        },
+        "type_id": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Record type ID"
+        },
+        "state_id": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Record state ID"
+        },
+        "description": {
+          "type": "string",
+          "description": "Record description"
+        },
+        "amount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Record amount"
+        },
+        "category_id": {
+          "type": "string",
+          "description": "Record category ID"
+        },
+        "date": {
+          "type": "string",
+          "description": "Record date in ISO8601 format"
+        },
+        "payment_method_id": {
+          "type": "string",
+          "description": "Payment method ID"
+        }
+      },
+      "required": [
+        "title",
+        "type_id",
+        "state_id",
+        "description",
+        "amount",
+        "category_id",
+        "date",
+        "payment_method_id"
+      ],
+      "description": "Create a Record"
+    },
+    "putApiV1RecordsId": {
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string",
+          "description": "Record title"
+        },
+        "type_id": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Record type ID"
+        },
+        "state_id": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Record state ID"
+        },
+        "description": {
+          "type": "string",
+          "description": "Record description"
+        },
+        "amount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Record amount"
+        },
+        "category_id": {
+          "type": "string",
+          "description": "Record category ID"
+        },
+        "date": {
+          "type": "string",
+          "description": "Record date in ISO8601 format"
+        },
+        "payment_method_id": {
+          "type": "string",
+          "description": "Payment method ID"
+        }
+      },
+      "required": [
+        "title",
+        "type_id",
+        "state_id",
+        "description",
+        "amount",
+        "category_id",
+        "date",
+        "payment_method_id"
+      ],
+      "description": "Update a Record"
+    },
+    "postApiV1Categories": {
+      "type": "object",
+      "properties": {
+        "label": {
+          "type": "string",
+          "description": "Category label"
+        }
+      },
+      "required": [
+        "label"
+      ],
+      "description": "Create a Category"
+    },
+    "putApiV1CategoriesId": {
+      "type": "object",
+      "properties": {
+        "label": {
+          "type": "string",
+          "description": "Category label"
+        }
+      },
+      "required": [
+        "label"
+      ],
+      "description": "Update a Category"
+    },
+    "postApiV1PaymentMethods": {
+      "type": "object",
+      "properties": {
+        "label": {
+          "type": "string",
+          "description": "PaymentMethod label"
+        },
+        "withdrawal_day_of_month": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Withdrawal day of month"
+        },
+        "closing_day_of_month": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Closing day of month",
+          "default": 0
+        }
+      },
+      "required": [
+        "label",
+        "withdrawal_day_of_month"
+      ],
+      "description": "Create a Payment Method"
+    },
+    "putApiV1PaymentMethodsId": {
+      "type": "object",
+      "properties": {
+        "label": {
+          "type": "string",
+          "description": "PaymentMethod label"
+        },
+        "withdrawal_day_of_month": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Withdrawal day of month"
+        },
+        "closing_day_of_month": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Closing day of month"
+        }
+      },
+      "required": [
+        "label",
+        "withdrawal_day_of_month"
+      ],
+      "description": "Update a Payment Method"
+    },
+    "postApiV1InvoiceRecords": {
+      "type": "object",
+      "properties": {
+        "amount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Invoice record amount"
+        },
+        "state_id": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Invoice record state ID"
+        },
+        "withdrawal_date": {
+          "type": "string",
+          "description": "Withdrawal date in ISO8601 format"
+        },
+        "payment_method_id": {
+          "type": "string",
+          "description": "Payment method ID"
+        }
+      },
+      "required": [
+        "amount",
+        "state_id",
+        "withdrawal_date",
+        "payment_method_id"
+      ],
+      "description": "Create an Invoice Record"
+    },
+    "putApiV1InvoiceRecordsId": {
+      "type": "object",
+      "properties": {
+        "amount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Invoice record amount"
+        },
+        "state_id": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Invoice record state ID"
+        },
+        "withdrawal_date": {
+          "type": "string",
+          "description": "Withdrawal date in ISO8601 format"
+        }
+      },
+      "required": [
+        "amount",
+        "state_id",
+        "withdrawal_date"
+      ],
+      "description": "Update an Invoice Record"
     }
   }
 }


### PR DESCRIPTION
swagger でレスポンスの形見えるようになった　ニコニコ

---
<!-- CLAUDE_CODE_REVIEW_START -->

_Claude Code Review_

## 概要

- (feat): OpenAPIドキュメント生成・閲覧機能を追加
- (feat): 全APIエンドポイントにSwagger仕様を追加してレスポンス構造を定義

## 変更内容

- `Makefile`: OpenAPIドキュメント生成(`update-openapi`)とSwagger UI起動(`openapi-viewer`)コマンドを追加。`help`コマンドの出力方法を簡略化
- `api/app/api/root.rb`: `grape-swagger-entity` gemを追加し、全エンティティモデルをSwagger設定に登録
- `api/app/api/v1/categories.rb`: 全エンドポイント(GET, POST, PUT)に`desc`とレスポンスエンティティを定義。パラメータブロックをエンドポイント外に移動
- `api/app/api/v1/invoice_records.rb`: 全エンドポイント(GET, POST, PUT, DELETE, aggregation)に`desc`とレスポンスエンティティを定義。パラメータ定義を整理
- `api/app/api/v1/payment_methods.rb`: 全エンドポイント(GET, POST, PUT)に`desc`とレスポンスエンティティを定義
- `api/app/api/v1/records.rb`: 全エンドポイント(GET, POST, PUT, DELETE)に`desc`とレスポンスエンティティを定義。`require`のtypoを`requires`に修正
- `api/app/api/v1/root.rb`: `/healthcheck`エンドポイントに説明を追加
- `api/app/api/v1/view.rb`: `/view/categories/aggregation`エンドポイントに`desc`とレスポンスエンティティを定義
- `docs/openapi_swagger_doc.json`: 全エンドポイントの詳細なOpenAPI仕様を含む完全なSwaggerドキュメントを生成(自動生成ファイル)

<!-- CLAUDE_CODE_REVIEW_END -->
