### PR TITLE
front: feat: SP（スマートフォン）対応 (#0010)

### DIFF
--- a/.claude/rules/front-component-structure.md
+++ b/.claude/rules/front-component-structure.md
@@ -37,3 +37,46 @@ CSS クラス命名規則は別ファイル `.claude/rules/front-style-naming.md
 - 未使用変数・引数は `_` プレフィックスで無視できる（例: `_error`, `_req`）
 - Svelte 5 のリアクティブ Map は `SvelteMap`（`svelte/reactivity`）を使う。`$state` でラップすると `svelte/no-unnecessary-state-wrap` エラーになるため不要
 - `SvelteMap` を変数ごと再代入するのではなく `.clear()` + `.set()` で変更する（再代入すると `$state` なしでは reactivity が失われる）
+
+## SP（スマートフォン）対応
+
+### ブレイクポイント
+
+`src/lib/styles/_variables.scss` に SP 用のブレイクポイントが定義されている。
+
+- `$bp-sp-min: 360px` — 想定する SP 最小幅（コンポーネント設計時の参照用）
+- `$bp-sp-max: 678px` — SP / デスクトップの境界。これ以下が SP レイアウト
+
+### メディアクエリの書き方（統一）
+
+デスクトップファーストで記述する。SP 用の上書きは以下の唯一のフォーマットで書く。
+
+```scss
+@media (max-width: $bp-sp-max) {
+  .layout-foo {
+    // SP 用の上書き
+  }
+}
+```
+
+- `max-width` を使う（`min-width` 併用、`between` 系は使わない）
+- 値は必ず `$bp-sp-max` を参照する（`678px` 直書き禁止）
+- ブロックは `<style>` 末尾にまとめて置く
+- SCSS 変数を参照するため `<style lang="scss">` を必ず付ける
+
+### 検証
+
+Chrome DevTools のデバイスツールバーで以下を目視確認する。
+
+- 360px / 678px / デスクトップ幅でビューポートからはみ出さない
+- 入力フォームがタップしやすい（最低 44px のタップ領域）
+- テーブルは `overflow-x: auto` でコンポーネント単位スクロール
+
+### 付記: マジックナンバーの扱い
+
+CSS の値（`px`, `rem`, `%` など）にマジックナンバーを使う場合、なぜその値かをコメントで残す。
+```scss
+.layout-foo {
+  padding: 12px 8px; // 12px = タップ領域確保、8px = 横詰め
+}
+```

--- a/.claude/rules/front-component-structure.md
+++ b/.claude/rules/front-component-structure.md
@@ -74,9 +74,23 @@ Chrome DevTools のデバイスツールバーで以下を目視確認する。
 
 ### 付記: マジックナンバーの扱い
 
-CSS の値（`px`, `rem`, `%` など）にマジックナンバーを使う場合、なぜその値かをコメントで残す。
+CSS の値そのものに**意図や非自明な背景**がある場合のみコメントを残す。値の単純な詰め・拡大・縮小（`padding: 8px 10px`、`font-size: 1.5rem` など）は CSS から自明なのでコメント不要。
+
+コメントを残す例:
+
+- ブレイクポイント値そのもの（なぜ `360px` / `678px` か）
+- iOS Safari のフォーカス時ズーム回避（`font-size: 1rem`）
+- flex item の暗黙の `min-width: auto` 解除目的の `min-width: 0`
+- 既存の `min-width` をあえて緩める / 解除する場合（理由があるはず）
+
 ```scss
 .layout-foo {
-  padding: 12px 8px; // 12px = タップ領域確保、8px = 横詰め
+  // flex item の暗黙の min-width: auto を解除し、子要素が親幅に追従できるようにする
+  min-width: 0;
+}
+
+input {
+  // 16px 未満だと iOS Safari がフォーカス時にズームしてしまうため 1rem
+  font-size: 1rem;
 }
 ```

--- a/docs/design-doc/0010-front-sp-responsive-support.md
+++ b/docs/design-doc/0010-front-sp-responsive-support.md
@@ -1,0 +1,244 @@
+# 0010 SP 対応（レスポンシブ）
+
+> **scope**: front | **date**: 2026-05-04 | **issue**: #32
+
+## 概要
+
+スマートフォン（SP）幅で各コンポーネントがビューポートからはみ出さないようにレスポンシブ対応を行う。あわせて、ブレイクポイントとメディアクエリの書き方を `_variables.scss` と `.claude/rules/` に集約し、初学者でも迷わず実装・拡張できる土台を整える。
+
+## 目標
+
+- SP 幅（360px / 678px）で全コンポーネントがはみ出さず閲覧・操作できる
+- 新規レコード入力フロー（`InvoiceRecordTableForm` および関連入力 UI）が SP で快適に使える
+- ブレイクポイント値が `_variables.scss` の SCSS 変数として一元管理される
+- メディアクエリの書き方が `.claude/rules/front-component-structure.md` の SP セクションで規約化されている
+- マジックナンバーには必ずコメントが付き、初学者が読んで意味が分かる
+- Chrome DevTools のデバイスツールバーで全コンポーネントを 360px / 678px / デスクトップで目視確認し、はみ出しがゼロ
+
+## 非目標
+
+- 機能追加（issue #32 にて明記）
+- ナビゲーション構造そのものの再設計（既存のハンバーガー方式を踏襲）
+- デザインシステム（色・タイポグラフィ）の刷新
+- アクセシビリティの抜本的見直し
+- タブレット専用の最適化（`md` 相当の中間レイアウトは作らない。`sm` 未満を SP、それ以上をデスクトップとする 2 段階）
+- E2E / Visual Regression テストの自動化（実機確認は人間が DevTools で行う）
+
+## 設計
+
+### ブレイクポイント方針
+
+#### 採用する値
+
+`front/src/lib/styles/_variables.scss` に SCSS 変数として定義する。CSS 変数化はしない（メディアクエリ条件には CSS 変数が使えないため）。
+
+```scss
+// SP（スマートフォン）対応のブレイクポイント
+// 360px: Android 一般的な最小幅 / iPhone SE 系より一回り狭い想定
+// 678px: タブレット縦 / 大きめ SP の境界（768px ではなく 678px を採用、PC 1 カラム表示の最小幅）
+$bp-sp-min: 360px;
+$bp-sp-max: 678px;
+```
+
+> 値は issue #32 でユーザーが指定した「360px と 678px を SP とする」に従う。
+
+#### レイアウト戦略
+
+**デスクトップファースト**で書く。既存スタイルはデスクトップ向けの記述のままとし、SP 向けの上書きを `@media (max-width: $bp-sp-max)` で追記していく。
+
+- 単一ブレイクポイント方式（`$bp-sp-max` 以下を SP として扱う）
+- `$bp-sp-min` は「想定する最小幅」のドキュメント用変数。確認時の最小幅として使う
+- モバイルファーストへは移行しない（既存資産を活かす + 初学者の認知負荷を下げる）
+
+#### メディアクエリの統一フォーマット
+
+`.claude/rules/front-component-structure.md` に SP セクションを追加し、以下を**唯一の書き方**として規約化する。
+
+```scss
+// SP 対応: 678px 以下で適用される
+@media (max-width: $bp-sp-max) {
+  .layout-foo {
+    // SP 用の上書き
+  }
+}
+```
+
+- 必ず `max-width` を使う（`min-width` 併用や `between` 系は使わない）
+- 必ず `$bp-sp-max` を使う（リテラル `678px` 直書き禁止）
+- メディアクエリブロックは各 `.svelte` の `<style>` 末尾にまとめて置く
+
+> dart-sass では `@media` 内の算術式を `#{}` で補間する必要があるが、変数を単独で使う場合は `#{}` 不要。Sidebar の既存記述 `@media (max-width: #{$px-sidebar-width + $px-main-max-width})` は算術が含まれるため `#{}` が必要なケース。
+
+### コンポーネント別の対応方針
+
+| コンポーネント | 優先度 | 方針 |
+|---|---|---|
+| `InvoiceRecordTableForm` | 最優先 | SP で快適に入力できること。テーブル列を間引く / 縦並びカード化を検討。横スクロール許容だが入力フィールドはタップしやすいサイズに |
+| `NumberDateField` | 最優先 | 数値入力 UI として SP でタップ・入力しやすいフォントサイズ・余白 |
+| `ExpenseDetails` | 高 | 入力フローの一部。SP 優先。日付セパレータ・テーブル幅調整 |
+| `MonthSelector` | 中 | 月切替ボタンの折り返し・タップ領域確保 |
+| `MainCategories` | 低 | SP では閲覧最低限。横スクロール許容、必要なら一部列を間引く |
+| `MonthlyExpenses` | 低 | 同上。集計表示は折りたたみ or 閲覧最低限 |
+| `CategoryDetails` | 低 | 同上 |
+| `Pagination` | 中 | ボタンが折り返さずに収まる、または横スクロールせずタップできる |
+| `Sidebar` | 対応済 | 既存ハンバーガーメニュー方式を維持。今回は手を入れない（あるいは新ブレイクポイントへの整理のみ） |
+
+#### 「最低限の閲覧」の定義
+
+非優先コンポーネントについて以下を満たせば OK とする:
+
+- ビューポートからはみ出さない（横スクロールバーが body レベルで出ない）
+- テーブル等は `overflow-x: auto` でコンポーネント単位の横スクロール許容
+- 列を間引いた場合は、表示しない列の情報が他の手段でアクセス可能（PC で見る等）
+
+#### 「あとから表示できるように」する手段
+
+issue で言及された「非表示でも、あとから表示できるようになっていればよい」については、今回は**コンポーネント単位の折りたたみ UI（accordion / details）等の追加実装は行わない**。SP では情報密度を下げて表示するに留め、機能追加は次回以降の issue とする。
+
+### `_variables.scss` の更新
+
+```scss
+$px-sidebar-width: 160px;
+$px-main-max-width: 1200px;
+
+// SP（スマートフォン）対応のブレイクポイント
+// 360px: 想定する SP 最小幅（Android 一般的な最小幅）
+// 678px: SP / デスクトップの境界。これ以下が SP レイアウト
+$bp-sp-min: 360px;
+$bp-sp-max: 678px;
+```
+
+### `.claude/rules/front-component-structure.md` の更新
+
+末尾に以下のセクションを追加する。
+
+```markdown
+## SP（スマートフォン）対応
+
+### ブレイクポイント
+
+`src/lib/styles/_variables.scss` に SP 用のブレイクポイントが定義されている。
+
+- `$bp-sp-min: 360px` — 想定する SP 最小幅（コンポーネント設計時の参照用）
+- `$bp-sp-max: 678px` — SP / デスクトップの境界。これ以下が SP レイアウト
+
+### メディアクエリの書き方（統一）
+
+デスクトップファーストで記述する。SP 用の上書きは以下の唯一のフォーマットで書く。
+
+\`\`\`scss
+@media (max-width: $bp-sp-max) {
+  .layout-foo {
+    // SP 用の上書き
+  }
+}
+\`\`\`
+
+- `max-width` を使う（`min-width` 併用、`between` 系は使わない）
+- 値は必ず `$bp-sp-max` を参照する（`678px` 直書き禁止）
+- ブロックは `<style>` 末尾にまとめて置く
+
+### 検証
+
+Chrome DevTools のデバイスツールバーで以下を目視確認する。
+
+- 360px / 678px / デスクトップ幅でビューポートからはみ出さない
+- 入力フォームがタップしやすい（最低 44px のタップ領域）
+- テーブルは `overflow-x: auto` でコンポーネント単位スクロール
+
+### 付記: マジックナンバーの扱い
+
+CSS の値（`px`, `rem`, `%` など）にマジックナンバーを使う場合、なぜその値かをコメントで残す。
+\`\`\`scss
+.layout-foo {
+  padding: 12px 8px; // 12px = タップ領域確保のため最低限、8px = 横詰め
+}
+\`\`\`
+```
+
+## 変更ファイル一覧
+
+実装時に変更が必要なファイル。AI が実装に取り掛かれるよう具体的に書く。
+
+### 設定・規約
+
+- `front/src/lib/styles/_variables.scss` — `$bp-sp-min`, `$bp-sp-max` を追加。コメント併記
+- `.claude/rules/front-component-structure.md` — 「SP（スマートフォン）対応」セクションを末尾に追加
+
+### コンポーネント（SP 用 `@media` ブロック追加）
+
+- `front/src/lib/components/InvoiceRecordTableForm.svelte` — SP で入力しやすいレイアウト。テーブル横スクロール or カード化、入力フィールドのフォント・余白調整
+- `front/src/lib/components/NumberDateField.svelte` — SP でタップしやすい入力エリア・フォントサイズ
+- `front/src/lib/components/ExpenseDetails.svelte` — SP でテーブルがはみ出さない、日付セパレータ調整
+- `front/src/lib/components/MonthSelector.svelte` — SP で月切替ボタンが折り返さず収まる
+- `front/src/lib/components/Pagination.svelte` — SP でページネーションボタンが収まる
+- `front/src/lib/components/MainCategories.svelte` — SP で横スクロール許容、必要なら列間引き
+- `front/src/lib/components/MonthlyExpenses.svelte` — 同上
+- `front/src/lib/components/CategoryDetails.svelte` — 同上
+
+### ページ
+
+- `front/src/routes/+page.svelte` — ページレベルのレイアウトに SP の余白・配置調整があれば追加
+- `front/src/routes/+layout.svelte` — 必要に応じて
+
+### 触らないファイル
+
+- `front/src/lib/components/Sidebar.svelte` — 既存のハンバーガー化が機能しているため、原則手を入れない。ただし `_variables.scss` の新変数を使うほうが綺麗なら整理してもよい（任意）
+
+## 実装ステップ
+
+依存関係を考慮した順序。各ステップは独立したコミット単位として書ける粒度。
+
+1. **規約とブレイクポイント変数の整備**
+   - `front/src/lib/styles/_variables.scss` に `$bp-sp-min`, `$bp-sp-max` を追加（コメント付き）
+   - `.claude/rules/front-component-structure.md` に SP セクションを追加
+   - `pnpm svelte-check && pnpm lint:style` で既存が壊れていないことを確認
+
+2. **入力系コンポーネントの SP 対応（最優先）**
+   - `NumberDateField.svelte`
+   - `InvoiceRecordTableForm.svelte`
+   - `ExpenseDetails.svelte`
+   - 各ファイルの `<style>` 末尾に統一フォーマットの `@media (max-width: $bp-sp-max)` ブロックを追加
+   - DevTools で 360px / 678px / デスクトップを目視確認
+
+3. **ナビゲーション系コンポーネントの SP 対応**
+   - `MonthSelector.svelte`
+   - `Pagination.svelte`
+
+4. **閲覧系コンポーネントの SP 対応（最低限）**
+   - `MainCategories.svelte`
+   - `MonthlyExpenses.svelte`
+   - `CategoryDetails.svelte`
+   - 横スクロール許容 / 列間引きの方針で対応
+
+5. **ページレベルの最終調整**
+   - `+page.svelte`, `+layout.svelte` のレイアウト・余白を SP 向けに調整
+   - 全画面を DevTools で再確認
+
+6. **検証とコミット**
+   - `pnpm svelte-check`, `pnpm eslint`, `pnpm lint:style` の 3 つすべてパス
+   - Design Doc 末尾に実装サマリーを追記
+   - コミット → ブランチ push → PR 作成
+
+## 代替案
+
+### モバイルファースト
+**不採用**。既存資産がデスクトップファーストで書かれており、書き換えコストとレビューコストが大きい。初学者が触る前提なら認知負荷の低いデスクトップファーストの方が安全。
+
+### Tailwind 風 `sm/md/lg/xl` 多段ブレイクポイント
+**不採用**。今回はタブレット最適化を非目標としており、2 段階で十分。ブレイクポイントが増えると初学者が混乱する。将来必要になれば `$bp-md`, `$bp-lg` を追加すれば拡張可能。
+
+### CSS 変数でブレイクポイントを管理
+**不採用**。CSS 変数（`var(--bp-sp-max)`）はメディアクエリ条件式で評価されない（`@media (max-width: var(...))` は動かない）。SCSS 変数で扱うのが標準。
+
+### SCSS mixin（`@mixin sp { @media ... }`）でラップ
+**今回は採用しない**。`@include sp { ... }` の方がタイプ量は少ないが、初学者が「mixin は何？」と引っかかる懸念がある。生の `@media (max-width: $bp-sp-max) { ... }` の方が標準的な CSS 知識でそのまま読める。次の SP 対応 issue で要望が出れば導入を検討する。
+
+### 列間引きを Svelte の `{#if}` で実装
+列の表示/非表示は CSS の `display: none` ではなく `{#if !isSp}` で DOM ごと出し分ける案。今回は **CSS の `display: none` を優先**する。理由は (a) JS で画面幅を監視するロジックが必要になり初学者には複雑、(b) スタイル層で完結する方が変更箇所が局所化される、(c) アクセシビリティで重大な問題が出る場面はテーブル列程度なら少ない。必要なら次回以降に検討。
+
+## 未解決事項
+
+- **`InvoiceRecordTableForm` の SP レイアウトの最終形**: 横スクロールで通すか、入力 UI をカード型に組み替えるか。実装着手時に DevTools で実際に並べてみて判断する。判断は実装者に委ねる
+- **テーブルの列間引き基準**: どの列を SP で隠すかは各テーブルで個別判断。原則「主キー的な列（日付・金額）は残す、補助列（メモ・カテゴリ詳細）は候補」
+- **タップ領域 44px の厳格適用**: 既存ボタンで 44px を満たさないものがある場合、SP のみ拡大するか全体で揃えるか。今回は **SP のみ拡大** で進めるが、デザイン整合に違和感が出たら相談

--- a/docs/design-doc/0010-front-sp-responsive-support.md
+++ b/docs/design-doc/0010-front-sp-responsive-support.md
@@ -242,3 +242,46 @@ CSS の値（`px`, `rem`, `%` など）にマジックナンバーを使う場�
 - **`InvoiceRecordTableForm` の SP レイアウトの最終形**: 横スクロールで通すか、入力 UI をカード型に組み替えるか。実装着手時に DevTools で実際に並べてみて判断する。判断は実装者に委ねる
 - **テーブルの列間引き基準**: どの列を SP で隠すかは各テーブルで個別判断。原則「主キー的な列（日付・金額）は残す、補助列（メモ・カテゴリ詳細）は候補」
 - **タップ領域 44px の厳格適用**: 既存ボタンで 44px を満たさないものがある場合、SP のみ拡大するか全体で揃えるか。今回は **SP のみ拡大** で進めるが、デザイン整合に違和感が出たら相談
+
+---
+
+## 実装サマリー
+
+> **実装日**: 2026-05-04
+
+### 変更ファイル
+
+- `front/src/lib/styles/_variables.scss` — `$bp-sp-min: 360px` / `$bp-sp-max: 678px` をコメント付きで追加
+- `.claude/rules/front-component-structure.md` — 「SP（スマートフォン）対応」セクションを末尾に追加（ブレイクポイント / メディアクエリ統一フォーマット / 検証 / マジックナンバー扱い）
+- `front/src/routes/+layout.svelte` — `.layout-app-wrapper` に `width: 100%` / `min-width: 0` / `overflow-x: hidden`、`.layout-main` に `min-width: 0` を追加
+- `front/src/routes/+page.svelte` — `.layout-page` / `.layout-summary` に `min-width: 0`、SP 用に余白・カードの `padding` / `border-radius` を縮小
+- `front/src/lib/components/NumberDateField.svelte` — SP で高さ・余白拡大、`font-size: 1rem` で iOS のズーム回避
+- `front/src/lib/components/InvoiceRecordTableForm.svelte` — テーブルを `layout-table-scroll` でラップして横スクロール許容、SP で入力 / ボタンサイズ拡大、`.layout-container` に `min-width: 0`
+- `front/src/lib/components/ExpenseDetails.svelte` — SP でセル余白詰め、入力サイズ拡大、用途列の幅縮小
+- `front/src/lib/components/MonthSelector.svelte` — SP で `flex-wrap`、ボタン / select の拡大
+- `front/src/lib/components/MonthlyExpenses.svelte` — SP で `min-width: 360px` 固定を解除、金額フォントを 2rem → 1.5rem に縮小
+- `front/src/lib/components/CategoryDetails.svelte` — SP で `min-width` 緩和、入力 / ボタン拡大、アクション列幅自動
+
+### 実装内容
+
+ddoc の設計通り、デスクトップファースト + 単一ブレイクポイント `$bp-sp-max` で `@media (max-width: $bp-sp-max) { ... }` の統一フォーマットを各コンポーネントの `<style lang="scss">` 末尾に追加した。マジックナンバーには日本語コメントを併記している。
+
+#### ddoc から外れた / 拡張した点
+
+- **`Pagination.svelte` / `MainCategories.svelte` は今回スキップ**: 前者は `classes.button: ''` などすべて空文字でスタイル実体が無いダミー実装、後者は CSS クラス未付与で `<style>` ブロックすら無い。SP 対応を入れても適用先が無いため、実体スタイルが入った時点で対応するのが妥当と判断した。
+- **`+layout.svelte` / `+page.svelte` / `InvoiceRecordTableForm.svelte` の親要素群に `min-width: 0` を追加**: 初回実装で DevTools 確認した際、テーブルの `min-width` が祖先の flex item を押し広げてビューポート全体が縮小レンダリングされる問題が発生した。原因は flexbox の暗黙の `min-width: auto`（flex item はコンテンツの最小幅までしか縮まない）。対応として、テーブルラッパー（`.layout-table-scroll`）に至るまでの祖先 flex item 全てに `min-width: 0` を追加した。最終防衛線として `.layout-app-wrapper` に `overflow-x: hidden` も付与した。
+- **`InvoiceRecordTableForm` の SP レイアウト**: 横スクロール許容で着地。テーブルの編集モード/表示モードを toggle する既存構造と縦並びカード化の相性が悪く、テーブルのほうが情報密度・入力フローが崩れない。
+- **タップ領域**: 厳密な 44px は満たしていない箇所があるが、入力 `height: 36px` + `padding: 8px 12px`、ボタン `padding: 8px 12px` で SP のみ拡大した。デザイン整合との折衷。
+
+### 確認・検証
+
+- `pnpm svelte-check` → **0 errors, 0 warnings**
+- `pnpm eslint` → **EXIT 0**
+- `pnpm lint:style` → **EXIT 0**
+- Chrome DevTools のデバイスツールバーで 360px / 678px / デスクトップを目視確認、ビューポートからのはみ出しが無いことを確認
+
+### 気づき・備考
+
+- **flexbox の `min-width: auto` 問題**は、レスポンシブ実装で必ず踏む地雷。テーブルや横長コンテンツを抱える flex 階層では、祖先の flex item 全てに `min-width: 0` を付ける必要がある。今後同種の対応をするときは、`overflow-x: auto` のラッパーを置くだけでなく **祖先の `min-width: 0` チェーン**を確認する手順をルール化する余地あり。
+- `<style>` を `<style lang="scss">` に変更する手間が複数ファイルで発生した。SCSS 変数を使えるよう、新規コンポーネントは最初から `<style lang="scss">` で書くよう `.claude/rules/front-component-structure.md` の SP セクションに明記済み。
+- `Pagination.svelte` / `MainCategories.svelte` は実装が入った時点で SP 対応を再確認する必要がある（フォローアップ issue 候補）。

--- a/front/src/lib/components/CategoryDetails.svelte
+++ b/front/src/lib/components/CategoryDetails.svelte
@@ -102,7 +102,7 @@
   </div>
 </div>
 
-<style>
+<style lang="scss">
   .layout-details {
     width: 100%;
   }
@@ -212,5 +212,30 @@
   .style-button-secondary:hover {
     background-color: #6c757d;
     color: white;
+  }
+
+  @media (max-width: $bp-sp-max) {
+    .style-table {
+      min-width: 320px; // 400px → 320px で SP 360px 幅に収まるよう緩和
+    }
+
+    .style-table th,
+    .style-table td {
+      padding: 8px 10px; // 16px → 10px で SP の横余白を詰める
+    }
+
+    .style-table input[type='text'] {
+      font-size: 1rem; // SP で意図しないズーム回避
+      height: 36px; // タップ領域確保
+    }
+
+    .style-button {
+      padding: 8px 12px; // SP でタップしやすく拡大
+      font-size: 0.875rem;
+    }
+
+    .layout-actions {
+      width: auto; // 160px 固定だと SP でアクション列が無駄に広い
+    }
   }
 </style>

--- a/front/src/lib/components/CategoryDetails.svelte
+++ b/front/src/lib/components/CategoryDetails.svelte
@@ -216,26 +216,28 @@
 
   @media (max-width: $bp-sp-max) {
     .style-table {
-      min-width: 320px; // 400px → 320px で SP 360px 幅に収まるよう緩和
+      // SP 360px 幅に収まるよう min-width を緩和
+      min-width: 320px;
     }
 
     .style-table th,
     .style-table td {
-      padding: 8px 10px; // 16px → 10px で SP の横余白を詰める
+      padding: 8px 10px;
     }
 
     .style-table input[type='text'] {
-      font-size: 1rem; // SP で意図しないズーム回避
-      height: 36px; // タップ領域確保
+      // 16px 未満だと iOS Safari がフォーカス時にズームしてしまうため 1rem
+      font-size: 1rem;
+      height: 36px;
     }
 
     .style-button {
-      padding: 8px 12px; // SP でタップしやすく拡大
+      padding: 8px 12px;
       font-size: 0.875rem;
     }
 
     .layout-actions {
-      width: auto; // 160px 固定だと SP でアクション列が無駄に広い
+      width: auto;
     }
   }
 </style>

--- a/front/src/lib/components/ExpenseDetails.svelte
+++ b/front/src/lib/components/ExpenseDetails.svelte
@@ -344,18 +344,19 @@
   @media (max-width: $bp-sp-max) {
     .style-table th,
     .style-table td {
-      padding: 8px 10px; // 横余白を 16px → 10px に詰める
+      padding: 8px 10px;
     }
 
     .style-table input[type='text'],
     .style-table input[type='number'],
     .style-table select {
-      font-size: 1rem; // SP で入力時の意図しないズーム回避
-      height: 36px; // SP タップ領域確保
+      // 16px 未満だと iOS Safari がフォーカス時にズームしてしまうため 1rem
+      font-size: 1rem;
+      height: 36px;
     }
 
     .style-button {
-      padding: 8px 12px; // SP でタップしやすいサイズに拡大
+      padding: 8px 12px;
       font-size: 0.875rem;
     }
 

--- a/front/src/lib/components/ExpenseDetails.svelte
+++ b/front/src/lib/components/ExpenseDetails.svelte
@@ -176,7 +176,7 @@
   </div>
 </div><!-- layout-details -->
 
-<style>
+<style lang="scss">
   .layout-details {
     width: 100%;
   }
@@ -339,5 +339,29 @@
   .style-button-danger:hover {
     background-color: #dc3545;
     color: white;
+  }
+
+  @media (max-width: $bp-sp-max) {
+    .style-table th,
+    .style-table td {
+      padding: 8px 10px; // 横余白を 16px → 10px に詰める
+    }
+
+    .style-table input[type='text'],
+    .style-table input[type='number'],
+    .style-table select {
+      font-size: 1rem; // SP で入力時の意図しないズーム回避
+      height: 36px; // SP タップ領域確保
+    }
+
+    .style-button {
+      padding: 8px 12px; // SP でタップしやすいサイズに拡大
+      font-size: 0.875rem;
+    }
+
+    .layout-title {
+      max-width: 200px;
+      min-width: 120px;
+    }
   }
 </style>

--- a/front/src/lib/components/InvoiceRecordTableForm.svelte
+++ b/front/src/lib/components/InvoiceRecordTableForm.svelte
@@ -143,6 +143,7 @@
   {#if loading}
     <p>読み込み中...</p>
   {:else}
+    <div class="layout-table-scroll">
     <table class="style-table">
       <thead>
         <tr>
@@ -230,20 +231,32 @@
         {/each}
       </tbody>
     </table>
+    </div>
   {/if}
 </div>
 
-<style>
+<style lang="scss">
   .layout-container {
     display: flex;
     flex-direction: column;
     align-items: center;
     margin-bottom: 24px;
+    min-width: 0; // 子のテーブルラッパーが親幅に追従できるよう暗黙の min-width: auto を解除
   }
 
-  .layout-container > .style-table {
+  .layout-container > .layout-table-scroll {
     width: 100%;
     max-width: 960px;
+  }
+
+  .layout-table-scroll {
+    overflow-x: auto;
+    width: 100%;
+    scrollbar-width: none;
+  }
+
+  .layout-table-scroll::-webkit-scrollbar {
+    display: none;
   }
 
   .style-table {
@@ -327,5 +340,27 @@
   .style-button-secondary:hover {
     background-color: #6c757d;
     color: white;
+  }
+
+  @media (max-width: $bp-sp-max) {
+    .style-table {
+      min-width: 720px; // 720px = SP では横スクロールで全列見せる（列を間引かない方針）
+    }
+
+    .style-table th,
+    .style-table td {
+      padding: 8px 10px; // 横余白を 16px から 10px に詰めて情報密度を上げる
+    }
+
+    .style-table input,
+    .style-table select {
+      font-size: 1rem; // SP で入力時の意図しないズーム回避
+      padding: 6px 8px; // タップ領域確保
+    }
+
+    .style-button {
+      padding: 8px 12px; // SP でタップしやすいサイズに拡大
+      font-size: 0.875rem;
+    }
   }
 </style>

--- a/front/src/lib/components/InvoiceRecordTableForm.svelte
+++ b/front/src/lib/components/InvoiceRecordTableForm.svelte
@@ -241,7 +241,8 @@
     flex-direction: column;
     align-items: center;
     margin-bottom: 24px;
-    min-width: 0; // 子のテーブルラッパーが親幅に追従できるよう暗黙の min-width: auto を解除
+    // flex item の暗黙の min-width: auto を解除し、子テーブルラッパーが親幅に追従できるようにする
+    min-width: 0;
   }
 
   .layout-container > .layout-table-scroll {
@@ -343,23 +344,25 @@
   }
 
   @media (max-width: $bp-sp-max) {
+    // SP では列を間引かず、横スクロールで全列を見せる
     .style-table {
-      min-width: 720px; // 720px = SP では横スクロールで全列見せる（列を間引かない方針）
+      min-width: 720px;
     }
 
     .style-table th,
     .style-table td {
-      padding: 8px 10px; // 横余白を 16px から 10px に詰めて情報密度を上げる
+      padding: 8px 10px;
     }
 
     .style-table input,
     .style-table select {
-      font-size: 1rem; // SP で入力時の意図しないズーム回避
-      padding: 6px 8px; // タップ領域確保
+      // 16px 未満だと iOS Safari がフォーカス時にズームしてしまうため 1rem
+      font-size: 1rem;
+      padding: 6px 8px;
     }
 
     .style-button {
-      padding: 8px 12px; // SP でタップしやすいサイズに拡大
+      padding: 8px 12px;
       font-size: 0.875rem;
     }
   }

--- a/front/src/lib/components/MonthSelector.svelte
+++ b/front/src/lib/components/MonthSelector.svelte
@@ -73,17 +73,18 @@
 
   @media (max-width: $bp-sp-max) {
     .layout-month-selector {
-      flex-wrap: wrap; // 幅が足りなくなったら折り返す
+      flex-wrap: wrap;
       gap: 6px;
     }
 
     .style-nav-button {
-      font-size: 1.25rem; // SP でタップしやすく拡大
+      font-size: 1.25rem;
       padding: 6px 10px;
     }
 
     .style-select {
-      font-size: 1rem; // SP で意図しないズーム回避
+      // 16px 未満だと iOS Safari がフォーカス時にズームしてしまうため 1rem
+      font-size: 1rem;
       padding: 6px 8px;
     }
   }

--- a/front/src/lib/components/MonthSelector.svelte
+++ b/front/src/lib/components/MonthSelector.svelte
@@ -41,7 +41,7 @@
   <button class="style-nav-button" onclick={nextMonth}>▶</button>
 </div>
 
-<style>
+<style lang="scss">
   .layout-month-selector {
     display: flex;
     align-items: center;
@@ -69,5 +69,22 @@
     cursor: pointer;
     background-color: var(--color-card-bg);
     color: inherit;
+  }
+
+  @media (max-width: $bp-sp-max) {
+    .layout-month-selector {
+      flex-wrap: wrap; // 幅が足りなくなったら折り返す
+      gap: 6px;
+    }
+
+    .style-nav-button {
+      font-size: 1.25rem; // SP でタップしやすく拡大
+      padding: 6px 10px;
+    }
+
+    .style-select {
+      font-size: 1rem; // SP で意図しないズーム回避
+      padding: 6px 8px;
+    }
   }
 </style>

--- a/front/src/lib/components/MonthlyExpenses.svelte
+++ b/front/src/lib/components/MonthlyExpenses.svelte
@@ -23,7 +23,7 @@
   <p>¥<span class="style-total-amount">{totalAmount.toLocaleString()}</span></p>
 </div>
 
-<style>
+<style lang="scss">
   .style-total {
     background-color: var(--color-card-bg);
     border: 1px solid var(--color-border);
@@ -43,5 +43,18 @@
   .style-total-amount {
     font-size: 2rem;
     font-weight: bold;
+  }
+
+  @media (max-width: $bp-sp-max) {
+    .style-total {
+      min-width: 0; // SP では親幅に合わせて縮小可能にする（360px 固定だとはみ出す）
+      width: 100%;
+      box-sizing: border-box;
+      padding: 12px; // 16px → 12px で SP の余白を詰める
+    }
+
+    .style-total-amount {
+      font-size: 1.5rem; // 2rem → 1.5rem で SP に収める
+    }
   }
 </style>

--- a/front/src/lib/components/MonthlyExpenses.svelte
+++ b/front/src/lib/components/MonthlyExpenses.svelte
@@ -47,14 +47,15 @@
 
   @media (max-width: $bp-sp-max) {
     .style-total {
-      min-width: 0; // SP では親幅に合わせて縮小可能にする（360px 固定だとはみ出す）
+      // デスクトップの min-width: 360px は SP 360px 幅で余白込みではみ出すため解除
+      min-width: 0;
       width: 100%;
       box-sizing: border-box;
-      padding: 12px; // 16px → 12px で SP の余白を詰める
+      padding: 12px;
     }
 
     .style-total-amount {
-      font-size: 1.5rem; // 2rem → 1.5rem で SP に収める
+      font-size: 1.5rem;
     }
   }
 </style>

--- a/front/src/lib/components/NumberDateField.svelte
+++ b/front/src/lib/components/NumberDateField.svelte
@@ -149,13 +149,14 @@
 
   @media (max-width: $bp-sp-max) {
     .layout-date-field {
-      height: 36px; // 36px = SP でタップ領域確保（min 44px に近づける）
-      padding: 6px 0; // 6px = 縦余白を増やしてタップしやすく
-      font-size: 1rem; // SP では入力時に意図しないズームを避けるため 16px 相当
+      height: 36px;
+      padding: 6px 0;
+      // 16px 未満だと iOS Safari がフォーカス時にズームしてしまうため 1rem
+      font-size: 1rem;
     }
 
     .layout-date-field input {
-      font-size: 1rem; // 同上
+      font-size: 1rem;
     }
   }
 </style>

--- a/front/src/lib/components/NumberDateField.svelte
+++ b/front/src/lib/components/NumberDateField.svelte
@@ -77,7 +77,7 @@
   />
 </div>
 
-<style>
+<style lang="scss">
   .layout-date-field {
     display: inline-flex;
     align-items: center;
@@ -146,4 +146,16 @@
     user-select: none;
   }
   /* stylelint-enable selector-class-pattern */
+
+  @media (max-width: $bp-sp-max) {
+    .layout-date-field {
+      height: 36px; // 36px = SP でタップ領域確保（min 44px に近づける）
+      padding: 6px 0; // 6px = 縦余白を増やしてタップしやすく
+      font-size: 1rem; // SP では入力時に意図しないズームを避けるため 16px 相当
+    }
+
+    .layout-date-field input {
+      font-size: 1rem; // 同上
+    }
+  }
 </style>

--- a/front/src/lib/styles/_variables.scss
+++ b/front/src/lib/styles/_variables.scss
@@ -1,2 +1,8 @@
 $px-sidebar-width: 160px;
 $px-main-max-width: 1200px;
+
+// SP（スマートフォン）対応のブレイクポイント
+// 360px: 想定する SP 最小幅（Android 一般的な最小幅）
+// 678px: SP / デスクトップの境界。これ以下が SP レイアウト
+$bp-sp-min: 360px;
+$bp-sp-max: 678px;

--- a/front/src/routes/+layout.svelte
+++ b/front/src/routes/+layout.svelte
@@ -29,10 +29,14 @@
   .layout-app-wrapper {
     display: flex;
     min-height: 100vh;
+    width: 100%;
+    min-width: 0; // flex 子が縮まれるよう、暗黙の min-width: auto を解除
+    overflow-x: hidden; // どこかで幅超過があってもビューポート外への押し出しを防ぐ最終防衛線
   }
 
   .layout-main {
     flex: 1;
+    min-width: 0; // 同上。子テーブルの min-width にこの要素が引きずられないように
     max-width: var(--px-main-max-width);
     margin: 0 auto;
   }

--- a/front/src/routes/+layout.svelte
+++ b/front/src/routes/+layout.svelte
@@ -30,13 +30,15 @@
     display: flex;
     min-height: 100vh;
     width: 100%;
-    min-width: 0; // flex 子が縮まれるよう、暗黙の min-width: auto を解除
-    overflow-x: hidden; // どこかで幅超過があってもビューポート外への押し出しを防ぐ最終防衛線
+    // flex item の暗黙の min-width: auto を解除し、子コンテンツが縮まれるようにする
+    min-width: 0;
+    // 幅超過が起きてもビューポート外への押し出しを防ぐ最終防衛線
+    overflow-x: hidden;
   }
 
   .layout-main {
     flex: 1;
-    min-width: 0; // 同上。子テーブルの min-width にこの要素が引きずられないように
+    min-width: 0;
     max-width: var(--px-main-max-width);
     margin: 0 auto;
   }

--- a/front/src/routes/+page.svelte
+++ b/front/src/routes/+page.svelte
@@ -30,12 +30,13 @@
   </div>
 </div>
 
-<style>
+<style lang="scss">
   .layout-page {
     display: flex;
     flex-direction: column;
     gap: 24px;
     padding: 24px;
+    min-width: 0; // 子のテーブル min-width で親が押し広げられないように
   }
 
   .layout-month-selector-wrapper {
@@ -45,6 +46,7 @@
   .layout-summary {
     display: flex;
     gap: 16px;
+    min-width: 0; // 同上（flex 子の暗黙 min-width: auto を解除）
   }
 
   .layout-section {
@@ -61,5 +63,17 @@
     border-radius: 12px;
     box-shadow: var(--shadow-md);
     padding: 24px;
+  }
+
+  @media (max-width: $bp-sp-max) {
+    .layout-page {
+      gap: 16px; // 24px → 16px で SP の余白を詰める
+      padding: 12px; // 24px → 12px。さらに左 8px のハンバーガーボタンと干渉しない最低限
+    }
+
+    .style-card {
+      padding: 12px; // 24px → 12px
+      border-radius: 8px; // 12px → 8px で SP の小型カードに合わせる
+    }
   }
 </style>

--- a/front/src/routes/+page.svelte
+++ b/front/src/routes/+page.svelte
@@ -36,7 +36,8 @@
     flex-direction: column;
     gap: 24px;
     padding: 24px;
-    min-width: 0; // 子のテーブル min-width で親が押し広げられないように
+    // flex item の暗黙の min-width: auto を解除（子テーブルの min-width で親が押し広げられるのを防ぐ）
+    min-width: 0;
   }
 
   .layout-month-selector-wrapper {
@@ -46,7 +47,7 @@
   .layout-summary {
     display: flex;
     gap: 16px;
-    min-width: 0; // 同上（flex 子の暗黙 min-width: auto を解除）
+    min-width: 0;
   }
 
   .layout-section {
@@ -67,13 +68,13 @@
 
   @media (max-width: $bp-sp-max) {
     .layout-page {
-      gap: 16px; // 24px → 16px で SP の余白を詰める
-      padding: 12px; // 24px → 12px。さらに左 8px のハンバーガーボタンと干渉しない最低限
+      gap: 16px;
+      padding: 12px;
     }
 
     .style-card {
-      padding: 12px; // 24px → 12px
-      border-radius: 8px; // 12px → 8px で SP の小型カードに合わせる
+      padding: 12px;
+      border-radius: 8px;
     }
   }
 </style>


### PR DESCRIPTION
# Changes

- (docs): design doc 0010 を追加（`docs/design-doc/0010-front-sp-responsive-support.md`）
- (feat): `_variables.scss` に SP 用ブレイクポイント `$bp-sp-min: 360px` / `$bp-sp-max: 678px` を追加
- (docs): `.claude/rules/front-component-structure.md` に「SP（スマートフォン）対応」セクションを追加（`@media (max-width: $bp-sp-max) { ... }` の統一フォーマット、`<style lang="scss">` 必須化、マジックナンバー方針）
- (feat): `NumberDateField` / `InvoiceRecordTableForm` / `ExpenseDetails` / `MonthSelector` / `MonthlyExpenses` / `CategoryDetails` に SP 用の `@media` ブロックを追加
- (feat): `InvoiceRecordTableForm` のテーブルを `layout-table-scroll` でラップして SP 横スクロール許容
- (fix): flex item の暗黙の `min-width: auto` でビューポートが押し広げられる問題を修正（`.layout-app-wrapper` / `.layout-main` / `.layout-page` / `.layout-summary` / `.layout-container` に `min-width: 0` を追加、`.layout-app-wrapper` に最終防衛線として `overflow-x: hidden`）
- (docs): CSS コメントを「意図や非自明な背景があるもののみ」に整理（flex `min-width: 0`、iOS Safari ズーム回避の `font-size: 1rem`、`min-width` の緩和理由など）

Closes #32.

<!-- CLAUDE_CODE_REVIEW_START -->

> ## Summary
>
> (feat) SP（スマートフォン）対応の基盤として SCSS ブレイクポイント変数 `$bp-sp-min` / `$bp-sp-max` を導入し、デスクトップファーストの単一メディアクエリ規約 `@media (max-width: $bp-sp-max) { ... }` を `.claude/rules` に明文化。
> (feat) 入力系・ナビ系・閲覧系の各コンポーネントに SP 用 `@media` ブロックを追加し、`InvoiceRecordTableForm` のテーブルは横スクロールラッパーで包んで SP でも全列を維持。
> (fix) flex 子孫テーブルの `min-width` がビューポートを押し広げる問題を、祖先の `min-width: 0` チェーンと `.layout-app-wrapper` の `overflow-x: hidden` で解消。
>
> ## Changes
>
> **(feat) ブレイクポイント基盤と規約 (`front/src/lib/styles/_variables.scss`, `.claude/rules/front-component-structure.md`)**
> - `$bp-sp-min: 360px` / `$bp-sp-max: 678px` を SCSS 変数として追加（CSS 変数は `@media` 条件で評価されないため SCSS 側）
> - rules に「SP 対応」セクションを追記。`@media (max-width: $bp-sp-max) { ... }` を唯一の書き方として規約化、`<style lang="scss">` を必須化
> - マジックナンバー方針を「すべての値にコメント」から「意図や非自明な背景があるもののみ」に改定
>
> **(feat) 入力系コンポーネントの SP 対応 (`front/src/lib/components/`)**
> - `NumberDateField.svelte`: 高さ・縦余白拡大、`font-size: 1rem`（iOS Safari のフォーカス時ズーム回避）
> - `InvoiceRecordTableForm.svelte`: テーブルを新設の `.layout-table-scroll` でラップして `overflow-x: auto`、SP では `min-width: 720px` を維持して列を間引かず横スクロールで全列表示
> - `ExpenseDetails.svelte`: SP でセル余白詰め、入力 `height: 36px`、用途列の `max-width` / `min-width` 縮小
>
> **(feat) ナビ・閲覧系コンポーネントの SP 対応 (`front/src/lib/components/`)**
> - `MonthSelector.svelte`: SP で `flex-wrap: wrap`、ナビボタン拡大、select の `font-size: 1rem`
> - `MonthlyExpenses.svelte`: デスクトップの `min-width: 360px` を SP では解除し `width: 100%` + `box-sizing: border-box`、金額は 2rem → 1.5rem
> - `CategoryDetails.svelte`: テーブルの `min-width` を 400px → 320px に緩和、入力 / ボタン拡大、アクション列を `width: auto`
>
> **(fix) flexbox の `min-width: auto` によるビューポート押し広げ (`front/src/routes/+layout.svelte`, `front/src/routes/+page.svelte`, `front/src/lib/components/InvoiceRecordTableForm.svelte`)**
> - `.layout-app-wrapper` / `.layout-main` / `.layout-page` / `.layout-summary` / `.layout-container` の各 flex item に `min-width: 0` を追加し、内部テーブルの `min-width` が祖先を押し広げないようにする
> - `.layout-app-wrapper` に `width: 100%` と最終防衛線の `overflow-x: hidden` を追加
> - `+page.svelte` に SP 用 `@media` ブロックを追加して `padding` / `gap` / カードの `padding` / `border-radius` を縮小
>
> **(docs) design doc 0010 と CSS コメント整理 (`docs/design-doc/0010-front-sp-responsive-support.md`)**
> - SP 対応の設計（ブレイクポイント、戦略、コンポーネント別方針、代替案、未解決事項）と実装サマリーを 1 ファイルに集約
> - 各コンポーネントの SP `@media` ブロック内のコメントを、自明な値変更（余白詰め・フォント縮小）からは除去し、`min-width: 0` の意図や iOS ズーム回避など非自明なものだけ残す
>
> _Summary via Claude Code_

<!-- CLAUDE_CODE_REVIEW_END -->