### PR TITLE
refactor: redesign Exceptions module as real class hierarchy (#48)

### DIFF
--- a/api/db/repositories.rb
+++ b/api/db/repositories.rb
@@ -81,13 +81,13 @@ module DB
         record = model.where(id:).first
         return record if record.update(**params)
 
-        raise Exceptions::InternalServerError.exception("failed to record update #{id}")
+        raise Exceptions::InternalServerError, "failed to record update #{id}"
       end
 
       def self.delete(id:)
         return if model.soft_delete(where_clause: { id: }).positive?
 
-        raise Exceptions::InternalServerError.exception("failed to record delete #{id}")
+        raise Exceptions::InternalServerError, "failed to record delete #{id}"
       end
 
       def self.get_aggregated_by_category(
@@ -199,7 +199,7 @@ module DB
         record = model.where(id:).first
         return record if record.update(**params)
 
-        raise Exceptions::InternalServerError.exception("failed to record update #{id}")
+        raise Exceptions::InternalServerError, "failed to record update #{id}"
       end
     end
 
@@ -227,7 +227,7 @@ module DB
         record = model.where(id:).first
         return record if record.update(**params)
 
-        raise Exceptions::InternalServerError.exception("failed to record update #{id}")
+        raise Exceptions::InternalServerError, "failed to record update #{id}"
       end
     end
 
@@ -267,13 +267,13 @@ module DB
         record = model.where(id:).first
         return record if record.update(**params)
 
-        raise Exceptions::InternalServerError.exception("failed to record update #{id}")
+        raise Exceptions::InternalServerError, "failed to record update #{id}"
       end
 
       def self.delete(id:)
         return if model.soft_delete(where_clause: { id: }).positive?
 
-        raise Exceptions::InternalServerError.exception("failed to delete invoice record #{id}")
+        raise Exceptions::InternalServerError, "failed to delete invoice record #{id}"
       end
     end
   end

--- a/api/lib/exceptions.rb
+++ b/api/lib/exceptions.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 module Exceptions
-  InternalServerError = StandardError.exception("Internal Server Error")
-  InvalidArgument = StandardError.exception("Invalid Argument")
-  NotFound = StandardError.exception("Not Found")
-  Unauthorized = StandardError.exception("Unauthorized")
+  class InternalServerError < StandardError; end
+  class InvalidArgument < StandardError; end
+  class NotFound < StandardError; end
+  class Unauthorized < StandardError; end
 end

--- a/api/lib/firebase.rb
+++ b/api/lib/firebase.rb
@@ -21,7 +21,7 @@ class Firebase
       url = "https://www.googleapis.com/service_accounts/v1/jwk/securetoken@system.gserviceaccount.com"
       res = Net::HTTP.get_response(URI.parse(url))
       puts res.inspect
-      raise Exceptions::InternalServerError.exception("failed to download Firebase jwk") if res.code != "200"
+      raise Exceptions::InternalServerError, "failed to download Firebase jwk" if res.code != "200"
 
       @expires_at = Time.now + 3600 # 1 hour
       puts "expires at: #{@expires_at}"
@@ -38,7 +38,7 @@ class Firebase
 
       { uid: header["user_id"], name: header["name"], picture_url: header["picture"] }
     rescue JWT::DecodeError => e
-      raise Exceptions::InternalServerError.exception("failed to decode JWT: #{e}")
+      raise Exceptions::Unauthorized, "failed to decode JWT: #{e}"
     end
   end
 end

--- a/api/services/categories.rb
+++ b/api/services/categories.rb
@@ -37,7 +37,7 @@ module Service
       params_dto = DB::Model::Category.dto.new(
         encrypted_label: params[:label]&.present? ? @uhash.encrypt(params[:label]) : nil
       ).to_h.compact
-      raise Exceptions::InvalidArgument.exception("no params to update") if params_dto.empty?
+      raise Exceptions::InvalidArgument, "no params to update" if params_dto.empty?
 
       DB::Repository::Category.update(id:, params: params_dto)
     end

--- a/api/services/invoice_records.rb
+++ b/api/services/invoice_records.rb
@@ -22,7 +22,7 @@ module Service
         payment_method_id: params[:payment_method_id],
         withdrawal_date: params[:withdrawal_date]
       )
-      raise Exceptions::InvalidArgument.exception("invalid dto") unless dto.valid?
+      raise Exceptions::InvalidArgument, "invalid dto" unless dto.valid?
 
       DB::Repository::InvoiceRecord.create(dto)
     end
@@ -33,7 +33,7 @@ module Service
         state_id: params[:state_id],
         withdrawal_date: params[:withdrawal_date]
       ).to_h.compact
-      raise Exceptions::InvalidArgument.exception("no params to update") if params_dto.empty?
+      raise Exceptions::InvalidArgument, "no params to update" if params_dto.empty?
 
       DB::Repository::InvoiceRecord.update(id:, params: params_dto)
     end
@@ -83,7 +83,7 @@ module Service
       # 支払い方法の情報を取得
       payment_method = DB::Repository::PaymentMethod.get(id: payment_method_id)
 
-      raise Exceptions::InvalidArgument.exception("payment method not found") unless payment_method
+      raise Exceptions::InvalidArgument, "payment method not found" unless payment_method
 
       # 締め期間を計算
       begin_date, end_date = DB::Repository::FinanceRecord.calculate_closing_period(

--- a/api/services/payment_methods.rb
+++ b/api/services/payment_methods.rb
@@ -42,7 +42,7 @@ module Service
         withdrawal_day_of_month: params[:withdrawal_day_of_month]&.present? ? params[:withdrawal_day_of_month] : nil,
         closing_day_of_month: params[:closing_day_of_month]&.present? ? params[:closing_day_of_month] : nil
       ).to_h.compact
-      raise Exceptions::InvalidArgument.exception("no params to update") if params_dto.empty?
+      raise Exceptions::InvalidArgument, "no params to update" if params_dto.empty?
 
       DB::Repository::PaymentMethod.update(id:, params: params_dto)
     end

--- a/api/services/records.rb
+++ b/api/services/records.rb
@@ -72,7 +72,7 @@ module Service
         date: params[:date],
         encrypted_description: @uhash.encrypt(params[:description])
       ).to_h.compact
-      raise Exceptions::InvalidArgument.exception("no params to update") if params_dto.empty?
+      raise Exceptions::InvalidArgument, "no params to update" if params_dto.empty?
 
       DB::Repository::FinanceRecord.update(id:, params: params_dto)
     end

--- a/api/spec/lib/exceptions_spec.rb
+++ b/api/spec/lib/exceptions_spec.rb
@@ -4,44 +4,44 @@ require "spec_helper"
 require "lib/exceptions"
 
 RSpec.describe Exceptions do
-  describe "クラス階層" do
-    it "InternalServerError は StandardError を継承する" do
+  describe "class hierarchy" do
+    it "InternalServerError inherits from StandardError" do
       expect(Exceptions::InternalServerError.ancestors).to include(StandardError)
     end
 
-    it "InvalidArgument は StandardError を継承する" do
+    it "InvalidArgument inherits from StandardError" do
       expect(Exceptions::InvalidArgument.ancestors).to include(StandardError)
     end
 
-    it "NotFound は StandardError を継承する" do
+    it "NotFound inherits from StandardError" do
       expect(Exceptions::NotFound.ancestors).to include(StandardError)
     end
 
-    it "Unauthorized は StandardError を継承する" do
+    it "Unauthorized inherits from StandardError" do
       expect(Exceptions::Unauthorized.ancestors).to include(StandardError)
     end
   end
 
-  describe "raise の挙動" do
-    it "メッセージ付きで raise できる" do
+  describe "raise behavior" do
+    it "can be raised with a message" do
       expect { raise Exceptions::NotFound, "missing" }
         .to raise_error(Exceptions::NotFound, "missing")
     end
 
-    it "引数なしでも raise できる" do
+    it "can be raised without arguments" do
       expect { raise Exceptions::InvalidArgument }
         .to raise_error(Exceptions::InvalidArgument)
     end
 
-    it "型による rescue が機能する（別クラスでは捕捉されない）" do
+    it "is not caught by rescue clause for a different class" do
       expect do
         raise Exceptions::InvalidArgument, "bad"
       rescue Exceptions::NotFound
-        # 捕捉されない想定
+        # not expected to be caught here
       end.to raise_error(Exceptions::InvalidArgument)
     end
 
-    it "型による rescue が機能する（同クラスで捕捉される）" do
+    it "is caught by rescue clause for the same class" do
       caught = nil
       begin
         raise Exceptions::Unauthorized, "no token"

--- a/api/spec/lib/exceptions_spec.rb
+++ b/api/spec/lib/exceptions_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "lib/exceptions"
+
+RSpec.describe Exceptions do
+  describe "クラス階層" do
+    it "InternalServerError は StandardError を継承する" do
+      expect(Exceptions::InternalServerError.ancestors).to include(StandardError)
+    end
+
+    it "InvalidArgument は StandardError を継承する" do
+      expect(Exceptions::InvalidArgument.ancestors).to include(StandardError)
+    end
+
+    it "NotFound は StandardError を継承する" do
+      expect(Exceptions::NotFound.ancestors).to include(StandardError)
+    end
+
+    it "Unauthorized は StandardError を継承する" do
+      expect(Exceptions::Unauthorized.ancestors).to include(StandardError)
+    end
+  end
+
+  describe "raise の挙動" do
+    it "メッセージ付きで raise できる" do
+      expect { raise Exceptions::NotFound, "missing" }
+        .to raise_error(Exceptions::NotFound, "missing")
+    end
+
+    it "引数なしでも raise できる" do
+      expect { raise Exceptions::InvalidArgument }
+        .to raise_error(Exceptions::InvalidArgument)
+    end
+
+    it "型による rescue が機能する（別クラスでは捕捉されない）" do
+      expect do
+        raise Exceptions::InvalidArgument, "bad"
+      rescue Exceptions::NotFound
+        # 捕捉されない想定
+      end.to raise_error(Exceptions::InvalidArgument)
+    end
+
+    it "型による rescue が機能する（同クラスで捕捉される）" do
+      caught = nil
+      begin
+        raise Exceptions::Unauthorized, "no token"
+      rescue Exceptions::Unauthorized => e
+        caught = e
+      end
+      expect(caught).to be_a(Exceptions::Unauthorized)
+      expect(caught.message).to eq("no token")
+    end
+  end
+end

--- a/docs/design-doc/0012-api-exceptions-class-hierarchy.md
+++ b/docs/design-doc/0012-api-exceptions-class-hierarchy.md
@@ -10,7 +10,7 @@
 
 - `Exceptions::InvalidArgument` などを独自クラスにし、`rescue Exceptions::NotFound => e` のような型分岐ができる構造にする
 - 利用側の `raise Exceptions::X.exception("msg")` を Ruby 標準の `raise Exceptions::X, "msg"` 形に統一する
-- Grape ルートで `rescue_from Exceptions::Unauthorized` 等の最小限の型別ハンドリングを 1 件追加し、新しい階層が機能することを示す
+- Firebase JWT デコード失敗を `Exceptions::Unauthorized` で raise するよう修正（階層化の効果を活かした最小限の意味修正）
 - 例外クラス階層の継承関係を確認する spec を追加する
 
 ## 非目標
@@ -55,9 +55,9 @@ end
 | `raise Exceptions::InternalServerError.exception("failed to ...")` | `raise Exceptions::InternalServerError, "failed to ..."` |
 | `raise Exceptions::InvalidArgument` | `raise Exceptions::InvalidArgument`（変更なし） |
 
-### Grape rescue_from の最小整備
+### Firebase JWT デコード失敗の例外型修正
 
-`api/app/api/root.rb` の `request_userdata` 内で、JWT デコードの結果として発生する `Firebase` 由来例外を区別する。現状は `rescue StandardError => e` で広く受けているため、新階層が機能することを示す最小例として `Exceptions::Unauthorized` を追加し、`Firebase.decode_jwt` 内で JWT 不正時にこれを raise するよう変更する。
+`api/lib/firebase.rb` の `JWT::DecodeError` ハンドリングは現在 `Exceptions::InternalServerError` で再 raise しているが、JWT デコード失敗は本来 401 (Unauthorized) であり 500 (InternalServerError) は意味的に誤り。クラス階層化のついでに `Exceptions::Unauthorized` に修正する。
 
 **現状（`api/lib/firebase.rb:40-42`）:**
 ```ruby
@@ -73,20 +73,7 @@ rescue JWT::DecodeError => e
 end
 ```
 
-**`api/app/api/root.rb:28-33` の rescue:**
-```ruby
-begin
-  Firebase.decode_jwt(jwt)
-rescue Exceptions::Unauthorized => e
-  puts e.inspect
-  error!({ error: "Invalid JWT", status: 401 }, 401)
-rescue StandardError => e
-  puts e.inspect
-  error!({ error: "Invalid JWT", status: 401 }, 401)
-end
-```
-
-JWT デコード失敗は本来 401 (Unauthorized) であり、500 (InternalServerError) で raise していた既存実装は意味的に誤り。階層化のついでに修正する。
+`api/app/api/root.rb:28-33` の `rescue StandardError => e` は現状維持。`Exceptions::Unauthorized` は `StandardError` 継承なのでこの rescue で問題なく捕捉され、401 を返す挙動は変わらない。型別 rescue_from の整備は #49 のスコープに委ねる。
 
 ### テスト
 
@@ -134,7 +121,6 @@ end
 - `api/services/categories.rb` — 行 40 を新形式に置換
 - `api/services/payment_methods.rb` — 行 34（変更不要、引数なし）, 行 45 を新形式に置換
 - `api/services/records.rb` — 行 75 を新形式に置換
-- `api/app/api/root.rb` — `Exceptions::Unauthorized` 用の rescue を 1 件追加（行 28-33）
 - `api/spec/lib/exceptions_spec.rb` — 新規、階層と raise 挙動の spec
 
 ## 実装ステップ
@@ -145,9 +131,8 @@ end
 2. `api/spec/lib/exceptions_spec.rb` を追加し、新階層が動作することをテストで担保
 3. 利用側 6 ファイル（`firebase.rb` / `repositories.rb` / `services/*.rb`）の `raise X.exception("msg")` を `raise X, "msg"` に一括置換
 4. `firebase.rb` の `JWT::DecodeError` ハンドリングを `Exceptions::Unauthorized` に変更
-5. `app/api/root.rb` に `rescue Exceptions::Unauthorized` を追加
-6. RSpec 全体を実行し、既存サービス層 spec を含めて全部緑になることを確認
-7. RuboCop / 型チェック相当のリンタを実行（`api/` には RuboCop あり）
+5. RSpec 全体を実行し、既存サービス層 spec を含めて全部緑になることを確認
+6. RuboCop / 型チェック相当のリンタを実行（`api/` には RuboCop あり）
 
 ## 代替案
 

--- a/docs/design-doc/0012-api-exceptions-class-hierarchy.md
+++ b/docs/design-doc/0012-api-exceptions-class-hierarchy.md
@@ -160,3 +160,37 @@ class InvalidArgument < Base; end
 ## 未解決事項
 
 - なし。後続 issue #49 で HTTP ステータス mapping を扱う際、本 doc で導入したクラス階層を前提に rescue_from を整備する。
+
+---
+
+## 実装サマリー
+
+> **実装日**: 2026-05-09
+
+### 変更ファイル
+
+- `api/lib/exceptions.rb` — 4 クラス（InternalServerError / InvalidArgument / NotFound / Unauthorized）を `class X < StandardError; end` の独立クラス定義に置換
+- `api/lib/firebase.rb` — `JWT::DecodeError` 捕捉時の再 raise を `Exceptions::Unauthorized` に変更（意味的修正）。`.exception("msg")` 記法も `, "msg"` に置換
+- `api/db/repositories.rb` — 6 箇所の `raise Exceptions::InternalServerError.exception("...")` を `raise Exceptions::InternalServerError, "..."` に置換
+- `api/services/categories.rb` — 1 箇所の記法置換
+- `api/services/invoice_records.rb` — 3 箇所の記法置換
+- `api/services/payment_methods.rb` — 1 箇所の記法置換（引数なし `raise Exceptions::InvalidArgument` 形は変更不要）
+- `api/services/records.rb` — 1 箇所の記法置換
+- `api/spec/lib/exceptions_spec.rb` — 新規。階層継承と raise 挙動（メッセージ付き / 引数なし / 型分岐）を 8 example で確認
+
+### 実装内容
+
+ddoc の設計通り、フラットなクラス階層（`Base` 中間なし）で実装した。利用側 6 ファイルの `raise X.exception("msg")` 記法を `raise X, "msg"` に統一し、Ruby 標準の raise シンタックスに揃えた。
+
+**ddoc から変更した点:** `app/api/root.rb` への `rescue Exceptions::Unauthorized` 追加を取りやめた。RuboCop の `Lint/DuplicateBranch` 指摘により、`Exceptions::Unauthorized` と `StandardError` の両 rescue が同一処理となるため重複指摘を受けた。`Exceptions::Unauthorized < StandardError` の継承関係により既存 `rescue StandardError => e` で問題なく捕捉される（型別ハンドリングは #49 のスコープで扱うのが適切）と判断し、`firebase.rb` 側の例外型修正のみ残した。
+
+### 確認・検証
+
+- `./scripts/test/api-test.sh` で全 RSpec を実行。新規 8 + 既存 6 = 14 examples 全 pass
+- 変更ファイルに対する RuboCop も実施。残った指摘 1 件（`app/api/root.rb:7` の `Style/RedundantCurrentDirectoryInPath`）は今回の変更と無関係な既存問題
+
+### 気づき・備考
+
+- `rescue Exceptions::Unauthorized, StandardError => e` の併記も RuboCop の重複検知に引っかかるため、Grape の rescue_from を使った真の型別 HTTP ステータス mapping は #49 で本格的に整備する必要がある
+- 既存の `payment_methods.rb:34` の引数なし `raise Exceptions::InvalidArgument` はクラス化後も問題なく動作（Ruby 標準の `raise Class` は `Class.new` と等価）
+- `Firebase.decode_jwt` の `JWT::DecodeError` ハンドリングが本来 401 だった点は ddoc 設計時に発見し、本 PR でついでに修正した。後続 #49 で HTTP ステータス mapping を実装する際にこの修正の意味が活きる

--- a/docs/design-doc/0012-api-exceptions-class-hierarchy.md
+++ b/docs/design-doc/0012-api-exceptions-class-hierarchy.md
@@ -1,0 +1,177 @@
+# 0012 Exceptions モジュールを真の例外クラス階層に再設計
+
+> **scope**: api | **date**: 2026-05-09 | **issue**: #48
+
+## 概要
+
+`api/lib/exceptions.rb` で `StandardError.exception("...")` で生成された「メッセージ付きインスタンス」を、独立した例外クラスに置き換え、Grape の `rescue_from` で型別ハンドリングを可能にする。
+
+## 目標
+
+- `Exceptions::InvalidArgument` などを独自クラスにし、`rescue Exceptions::NotFound => e` のような型分岐ができる構造にする
+- 利用側の `raise Exceptions::X.exception("msg")` を Ruby 標準の `raise Exceptions::X, "msg"` 形に統一する
+- Grape ルートで `rescue_from Exceptions::Unauthorized` 等の最小限の型別ハンドリングを 1 件追加し、新しい階層が機能することを示す
+- 例外クラス階層の継承関係を確認する spec を追加する
+
+## 非目標
+
+- 全 HTTP ステータスへの完全 mapping (NotFound→404, InvalidArgument→400, …) — これは後続 issue #49（エラー規約）で扱う
+- 既存の `rescue StandardError => e` (`api/app/api/root.rb:30`) の全面的な書き換え — `request_userdata` 内の JWT デコード失敗ハンドリングは現状維持
+- `Exceptions::NotFound` を未使用箇所（`update`/`delete` の id 不在ケース）に新規適用すること — これは別 issue #41 が扱う
+- Service / Repository 層の責務再整理 — #50 のスコープ
+
+## 設計
+
+### 例外クラス階層
+
+`api/lib/exceptions.rb` をフラットな個別クラス継承に置き換える。中間 `Base` を挟まずシンプルさを優先する。
+
+```ruby
+# frozen_string_literal: true
+
+module Exceptions
+  class InternalServerError < StandardError; end
+  class InvalidArgument < StandardError; end
+  class NotFound < StandardError; end
+  class Unauthorized < StandardError; end
+end
+```
+
+**設計判断:**
+
+- 中間 Base を挟まない理由: 現状エラーは 4 種のみで、共通の振る舞いを持たせる予定もないため、`Exceptions::Base` を挟む価値が低い。型分岐は個別クラスで十分達成できる。
+- `frozen_string_literal: true` は既存維持。
+- すべて `StandardError` 直下で、各クラスは空実装（メッセージは `raise` 時に渡す）。
+
+### 利用側の書き換え
+
+`raise Exceptions::X.exception("msg")` → `raise Exceptions::X, "msg"` に統一する。引数なしの `raise Exceptions::InvalidArgument` 形（`payment_methods.rb:34`）はそのままで動作する（Ruby 標準）。
+
+**変更パターン:**
+
+| Before | After |
+|--------|-------|
+| `raise Exceptions::InvalidArgument.exception("no params to update")` | `raise Exceptions::InvalidArgument, "no params to update"` |
+| `raise Exceptions::InternalServerError.exception("failed to ...")` | `raise Exceptions::InternalServerError, "failed to ..."` |
+| `raise Exceptions::InvalidArgument` | `raise Exceptions::InvalidArgument`（変更なし） |
+
+### Grape rescue_from の最小整備
+
+`api/app/api/root.rb` の `request_userdata` 内で、JWT デコードの結果として発生する `Firebase` 由来例外を区別する。現状は `rescue StandardError => e` で広く受けているため、新階層が機能することを示す最小例として `Exceptions::Unauthorized` を追加し、`Firebase.decode_jwt` 内で JWT 不正時にこれを raise するよう変更する。
+
+**現状（`api/lib/firebase.rb:40-42`）:**
+```ruby
+rescue JWT::DecodeError => e
+  raise Exceptions::InternalServerError.exception("failed to decode JWT: #{e}")
+end
+```
+
+**変更後:**
+```ruby
+rescue JWT::DecodeError => e
+  raise Exceptions::Unauthorized, "failed to decode JWT: #{e}"
+end
+```
+
+**`api/app/api/root.rb:28-33` の rescue:**
+```ruby
+begin
+  Firebase.decode_jwt(jwt)
+rescue Exceptions::Unauthorized => e
+  puts e.inspect
+  error!({ error: "Invalid JWT", status: 401 }, 401)
+rescue StandardError => e
+  puts e.inspect
+  error!({ error: "Invalid JWT", status: 401 }, 401)
+end
+```
+
+JWT デコード失敗は本来 401 (Unauthorized) であり、500 (InternalServerError) で raise していた既存実装は意味的に誤り。階層化のついでに修正する。
+
+### テスト
+
+`api/spec/lib/exceptions_spec.rb` を新規作成し、各例外クラスが `StandardError` を継承していること、メッセージ付き raise が動作することを確認する。
+
+```ruby
+require "spec_helper"
+require "lib/exceptions"
+
+RSpec.describe Exceptions do
+  describe "クラス階層" do
+    it "InvalidArgument は StandardError を継承する" do
+      expect(Exceptions::InvalidArgument.ancestors).to include(StandardError)
+    end
+    # 他 3 クラスも同様
+  end
+
+  describe "raise の挙動" do
+    it "メッセージ付きで raise できる" do
+      expect { raise Exceptions::NotFound, "missing" }
+        .to raise_error(Exceptions::NotFound, "missing")
+    end
+
+    it "型による rescue が機能する" do
+      expect {
+        begin
+          raise Exceptions::InvalidArgument, "bad"
+        rescue Exceptions::NotFound
+          # 捕捉されない
+        end
+      }.to raise_error(Exceptions::InvalidArgument)
+    end
+  end
+end
+```
+
+既存のサービス層 spec が引き続き通ることが受け入れ条件。
+
+## 変更ファイル一覧
+
+- `api/lib/exceptions.rb` — クラス階層に置換
+- `api/lib/firebase.rb` — `JWT::DecodeError` を `Exceptions::Unauthorized` で raise（行 41）。`raise Exceptions::InternalServerError.exception(...)` も新形式に置換（行 24）
+- `api/db/repositories.rb` — `raise Exceptions::InternalServerError.exception(...)` を新形式に置換（行 84, 90, 202, 230, 270, 276）
+- `api/services/invoice_records.rb` — 行 25, 36, 86 を新形式に置換
+- `api/services/categories.rb` — 行 40 を新形式に置換
+- `api/services/payment_methods.rb` — 行 34（変更不要、引数なし）, 行 45 を新形式に置換
+- `api/services/records.rb` — 行 75 を新形式に置換
+- `api/app/api/root.rb` — `Exceptions::Unauthorized` 用の rescue を 1 件追加（行 28-33）
+- `api/spec/lib/exceptions_spec.rb` — 新規、階層と raise 挙動の spec
+
+## 実装ステップ
+
+各ステップを独立コミットにできる順序で書く。
+
+1. `api/lib/exceptions.rb` をクラス階層に置換
+2. `api/spec/lib/exceptions_spec.rb` を追加し、新階層が動作することをテストで担保
+3. 利用側 6 ファイル（`firebase.rb` / `repositories.rb` / `services/*.rb`）の `raise X.exception("msg")` を `raise X, "msg"` に一括置換
+4. `firebase.rb` の `JWT::DecodeError` ハンドリングを `Exceptions::Unauthorized` に変更
+5. `app/api/root.rb` に `rescue Exceptions::Unauthorized` を追加
+6. RSpec 全体を実行し、既存サービス層 spec を含めて全部緑になることを確認
+7. RuboCop / 型チェック相当のリンタを実行（`api/` には RuboCop あり）
+
+## 代替案
+
+### 案 A: 中間 `Exceptions::Base` を挟む
+
+```ruby
+class Base < StandardError; end
+class InvalidArgument < Base; end
+```
+
+**却下理由:** Grape の `rescue_from Exceptions::Base` で「Exceptions 系全部」を一括キャッチする使い方を想定すれば有用だが、現状その用途がなく、後から必要になれば階層を一段足すのは容易。今は最小構造を採る。
+
+### 案 B: 3 階層（Client/Server を中間に置く）
+
+`ClientError`（4xx 想定）と `ServerError`（5xx 想定）を中間に挟む。
+
+**却下理由:** HTTP ステータス対応は #49 のスコープであり、階層に意味を持たせるなら #49 と一緒に設計すべき。今 #48 のスコープで先取りすると #49 の設計余地を狭める。
+
+### 案 C: `.exception("msg")` 記法を残す
+
+クラス化しても `.exception("msg")` は ClassMethod として動くため後方互換は保たれる。
+
+**却下理由:** Ruby 標準の `raise Class, "msg"` 形に揃えた方が他コードベースと一貫性がある。混在は将来の混乱要因。
+
+## 未解決事項
+
+- なし。後続 issue #49 で HTTP ステータス mapping を扱う際、本 doc で導入したクラス階層を前提に rescue_from を整備する。


### PR DESCRIPTION
# What

`api/lib/exceptions.rb` の各「例外」が `StandardError.exception("...")` で生成されたインスタンスだったため、`rescue Exceptions::NotFound => e` のような型分岐ができなかった。これを独立した例外クラスに置き換え、Grape の `rescue_from` で型別ハンドリング可能な土台を整える。詳細は `docs/design-doc/0012-api-exceptions-class-hierarchy.md` を参照。

Closes #48

# Changes

- (refactor): `api/lib/exceptions.rb` の 4 つを `class X < StandardError; end` の独立クラスに置換
- (refactor): 利用側 6 ファイル（firebase / repositories / services 4 つ）の `raise X.exception("msg")` を `raise X, "msg"` に統一
- (fix): `Firebase.decode_jwt` の `JWT::DecodeError` を `Exceptions::Unauthorized` で raise（従来は `InternalServerError` で意味的に誤りだった）
- (test): `api/spec/lib/exceptions_spec.rb` を新規追加（階層継承と raise 挙動を 8 example で確認）
- (docs): `docs/design-doc/0012-api-exceptions-class-hierarchy.md` を追加、実装サマリーも追記