### PR TITLE
fix(api): include month-end in InvoiceRecord.monthly_records date range (#42)

### DIFF
--- a/api/db/repositories.rb
+++ b/api/db/repositories.rb
@@ -205,7 +205,7 @@ module DB
                        .where(
                          deleted_at: nil,
                          hashed_user_id:,
-                         withdrawal_date: Date.new(year, month)...Date.new(year, month).end_of_month
+                         withdrawal_date: Date.new(year, month)..Date.new(year, month).end_of_month
                        )
         records.map do |record|
           model.to_dto(record).to_h.merge(


### PR DESCRIPTION
# What

Issue #42 のバグ修正。`InvoiceRecord.monthly_records` の日付範囲が排他演算子 \`...\` で構築されており、月末日（例: 1/31）の \`withdrawal_date\` を持つレコードが集計から漏れていた。

# Changes

- (fix): \`api/db/repositories.rb:208\` の \`Date.new(year, month)...Date.new(year, month).end_of_month\` を inclusive な \`..\` に修正

Refs: #42