### PR TITLE
refactor: unify API error handling and clean up repository/service layers

### DIFF
--- a/api/app/api/root.rb
+++ b/api/app/api/root.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "grape"
+require "lib/exceptions"
 require "lib/firebase"
 require "grape-swagger"
 require "grape-swagger-entity"
@@ -9,6 +10,11 @@ require_relative "./v1/root"
 module API
   class Root < Grape::API
     format :json
+
+    rescue_from Exceptions::Base do |e|
+      error!({ error: e.message, status: e.http_status }, e.http_status)
+    end
+
     helpers do
       def authorization_header
         headers["Authorization"]
@@ -25,12 +31,9 @@ module API
         jwt = authorization_header&.gsub("Bearer ", "")
         return { uid: Constants::EXAMPLE_USER_UID } if jwt.blank?
 
-        begin
-          Firebase.decode_jwt(jwt)
-        rescue StandardError => e
-          puts e.inspect
-          error!({ error: "Invalid JWT", status: 401 }, 401)
-        end
+        # JWT failures raise Exceptions::Unauthorized / InternalServerError,
+        # which rescue_from maps to the right HTTP status.
+        Firebase.decode_jwt(jwt)
       end
 
       # Present a create/update mutation result with Common::Response.

--- a/api/db/basewrapper.rb
+++ b/api/db/basewrapper.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "lib/exceptions"
+
 module DB
   module Model
     # BaseWrapper
@@ -35,6 +37,13 @@ module DB
 
           def valid?
             invalid_members.empty?
+          end
+
+          # Raises InvalidArgument listing the nil members when invalid.
+          def validate!
+            return if valid?
+
+            raise Exceptions::InvalidArgument, "missing required fields: #{invalid_members.join(', ')}"
           end
         end
         const_set("DTO", str)

--- a/api/db/basewrapper.rb
+++ b/api/db/basewrapper.rb
@@ -24,19 +24,17 @@ module DB
           *columns,
           keyword_init: true
         ) do
-          def valid?
-            # とりあえず nil チェックだけ
-            # TODO: NOT NULL だけコレにする
-            is_valid = true
-            members.each do |m|
-              next if [:created_at, :updated_at, :deleted_at].include?(m)
-
-              if self[m].nil?
-                is_valid = false
-                puts "Invalid: #{m} is nil" # TODO: logger にする
-              end
+          # Members that are nil and therefore fail validation.
+          # Timestamp columns are exempt.
+          # TODO: derive required members from NOT NULL constraints
+          def invalid_members
+            members.reject do |m|
+              [:created_at, :updated_at, :deleted_at].include?(m) || !self[m].nil?
             end
-            is_valid
+          end
+
+          def valid?
+            invalid_members.empty?
           end
         end
         const_set("DTO", str)

--- a/api/db/repositories.rb
+++ b/api/db/repositories.rb
@@ -6,7 +6,42 @@ require "lib/user_hash"
 
 module DB
   module Repository
+    # Shared mutation helpers extended onto repository classes.
+    # Each module relies on the host class defining `self.model`.
+
+    # Provides `create(dto)`.
+    module Creatable
+      def create(dto)
+        model.create(**dto.to_h)
+      end
+    end
+
+    # Provides `update(id:, params:)`.
+    # Raises NotFound when the record is missing, InternalServerError on failure.
+    module Updatable
+      def update(id:, params:)
+        record = model.where(id:).first
+        raise Exceptions::NotFound, "record not found: #{id}" if record.nil?
+        return record if record.update(**params)
+
+        raise Exceptions::InternalServerError, "failed to record update #{id}"
+      end
+    end
+
+    # Provides `delete(id:)` via soft delete. Raises NotFound when nothing matched.
+    module SoftDeletable
+      def delete(id:)
+        return if model.soft_delete(where_clause: { id: }).positive?
+
+        raise Exceptions::NotFound, "record not found: #{id}"
+      end
+    end
+
     class FinanceRecord
+      extend Creatable
+      extend Updatable
+      extend SoftDeletable
+
       def self.model
         @model ||= DB::Model::FinanceRecord
       end
@@ -29,24 +64,6 @@ module DB
             }
           )
         end
-      end
-
-      def self.create(dto)
-        model.create(**dto.to_h)
-      end
-
-      def self.update(id:, params:)
-        record = model.where(id:).first
-        raise Exceptions::NotFound, "record not found: #{id}" if record.nil?
-        return record if record.update(**params)
-
-        raise Exceptions::InternalServerError, "failed to record update #{id}"
-      end
-
-      def self.delete(id:)
-        return if model.soft_delete(where_clause: { id: }).positive?
-
-        raise Exceptions::NotFound, "record not found: #{id}"
       end
 
       def self.get_aggregated_by_category(
@@ -139,6 +156,9 @@ module DB
     end
 
     class Category
+      extend Creatable
+      extend Updatable
+
       def self.model
         @model ||= DB::Model::Category
       end
@@ -149,21 +169,12 @@ module DB
           model.to_dto(record).to_h
         end
       end
-
-      def self.create(dto)
-        model.create(**dto.to_h)
-      end
-
-      def self.update(id:, params:)
-        record = model.where(id:).first
-        raise Exceptions::NotFound, "record not found: #{id}" if record.nil?
-        return record if record.update(**params)
-
-        raise Exceptions::InternalServerError, "failed to record update #{id}"
-      end
     end
 
     class PaymentMethod
+      extend Creatable
+      extend Updatable
+
       def self.model
         @model ||= DB::Model::PaymentMethod
       end
@@ -178,21 +189,13 @@ module DB
           model.to_dto(record).to_h
         end
       end
-
-      def self.create(dto)
-        model.create(**dto.to_h)
-      end
-
-      def self.update(id:, params:)
-        record = model.where(id:).first
-        raise Exceptions::NotFound, "record not found: #{id}" if record.nil?
-        return record if record.update(**params)
-
-        raise Exceptions::InternalServerError, "failed to record update #{id}"
-      end
     end
 
     class InvoiceRecord
+      extend Creatable
+      extend Updatable
+      extend SoftDeletable
+
       def self.model
         @model ||= DB::Model::InvoiceRecord
       end
@@ -218,24 +221,6 @@ module DB
             }
           )
         end
-      end
-
-      def self.create(dto)
-        model.create(**dto.to_h)
-      end
-
-      def self.update(id:, params:)
-        record = model.where(id:).first
-        raise Exceptions::NotFound, "record not found: #{id}" if record.nil?
-        return record if record.update(**params)
-
-        raise Exceptions::InternalServerError, "failed to record update #{id}"
-      end
-
-      def self.delete(id:)
-        return if model.soft_delete(where_clause: { id: }).positive?
-
-        raise Exceptions::NotFound, "invoice record not found: #{id}"
       end
     end
   end

--- a/api/db/repositories.rb
+++ b/api/db/repositories.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "kaminari"
+require "lib/exceptions"
 require "lib/user_hash"
 
 module DB
@@ -36,6 +37,7 @@ module DB
 
       def self.update(id:, params:)
         record = model.where(id:).first
+        raise Exceptions::NotFound, "record not found: #{id}" if record.nil?
         return record if record.update(**params)
 
         raise Exceptions::InternalServerError, "failed to record update #{id}"
@@ -44,7 +46,7 @@ module DB
       def self.delete(id:)
         return if model.soft_delete(where_clause: { id: }).positive?
 
-        raise Exceptions::InternalServerError, "failed to record delete #{id}"
+        raise Exceptions::NotFound, "record not found: #{id}"
       end
 
       def self.get_aggregated_by_category(
@@ -154,6 +156,7 @@ module DB
 
       def self.update(id:, params:)
         record = model.where(id:).first
+        raise Exceptions::NotFound, "record not found: #{id}" if record.nil?
         return record if record.update(**params)
 
         raise Exceptions::InternalServerError, "failed to record update #{id}"
@@ -182,6 +185,7 @@ module DB
 
       def self.update(id:, params:)
         record = model.where(id:).first
+        raise Exceptions::NotFound, "record not found: #{id}" if record.nil?
         return record if record.update(**params)
 
         raise Exceptions::InternalServerError, "failed to record update #{id}"
@@ -222,6 +226,7 @@ module DB
 
       def self.update(id:, params:)
         record = model.where(id:).first
+        raise Exceptions::NotFound, "record not found: #{id}" if record.nil?
         return record if record.update(**params)
 
         raise Exceptions::InternalServerError, "failed to record update #{id}"
@@ -230,7 +235,7 @@ module DB
       def self.delete(id:)
         return if model.soft_delete(where_clause: { id: }).positive?
 
-        raise Exceptions::InternalServerError, "failed to delete invoice record #{id}"
+        raise Exceptions::NotFound, "invoice record not found: #{id}"
       end
     end
   end

--- a/api/lib/exceptions.rb
+++ b/api/lib/exceptions.rb
@@ -1,8 +1,38 @@
 # frozen_string_literal: true
 
 module Exceptions
-  class InternalServerError < StandardError; end
-  class InvalidArgument < StandardError; end
-  class NotFound < StandardError; end
-  class Unauthorized < StandardError; end
+  # Base class carrying the HTTP status that the API layer maps the exception to.
+  class Base < StandardError
+    def self.http_status
+      500
+    end
+
+    def http_status
+      self.class.http_status
+    end
+  end
+
+  class InternalServerError < Base
+    def self.http_status
+      500
+    end
+  end
+
+  class InvalidArgument < Base
+    def self.http_status
+      422
+    end
+  end
+
+  class NotFound < Base
+    def self.http_status
+      404
+    end
+  end
+
+  class Unauthorized < Base
+    def self.http_status
+      401
+    end
+  end
 end

--- a/api/services/categories.rb
+++ b/api/services/categories.rb
@@ -26,7 +26,7 @@ module Service
         hashed_user_id: @hashed_uid,
         encrypted_label: @uhash.encrypt(params[:label])
       )
-      raise Exceptions::InvalidArgument, "missing required fields: #{dto.invalid_members.join(', ')}" unless dto.valid?
+      dto.validate!
 
       DB::Repository::Category.create(dto)
     end

--- a/api/services/categories.rb
+++ b/api/services/categories.rb
@@ -3,6 +3,7 @@
 require "constants"
 require "db/repositories"
 require "lib/category_formatter"
+require "lib/exceptions"
 require "lib/id"
 
 module Service
@@ -25,7 +26,7 @@ module Service
         hashed_user_id: @hashed_uid,
         encrypted_label: @uhash.encrypt(params[:label])
       )
-      raise StandardError unless dto.valid?
+      raise Exceptions::InvalidArgument, "missing required fields: #{dto.invalid_members.join(', ')}" unless dto.valid?
 
       DB::Repository::Category.create(dto)
     end

--- a/api/services/invoice_records.rb
+++ b/api/services/invoice_records.rb
@@ -26,7 +26,7 @@ module Service
         payment_method_id: params[:payment_method_id],
         withdrawal_date: params[:withdrawal_date]
       )
-      raise Exceptions::InvalidArgument, "missing required fields: #{dto.invalid_members.join(', ')}" unless dto.valid?
+      dto.validate!
 
       DB::Repository::InvoiceRecord.create(dto)
     end

--- a/api/services/invoice_records.rb
+++ b/api/services/invoice_records.rb
@@ -3,6 +3,7 @@
 require "constants"
 require "db/repositories"
 require "lib/closing_period"
+require "lib/exceptions"
 require "lib/finance_record_formatter"
 require "lib/id"
 require "lib/invoice_record_formatter"
@@ -25,7 +26,7 @@ module Service
         payment_method_id: params[:payment_method_id],
         withdrawal_date: params[:withdrawal_date]
       )
-      raise Exceptions::InvalidArgument, "invalid dto" unless dto.valid?
+      raise Exceptions::InvalidArgument, "missing required fields: #{dto.invalid_members.join(', ')}" unless dto.valid?
 
       DB::Repository::InvoiceRecord.create(dto)
     end

--- a/api/services/payment_methods.rb
+++ b/api/services/payment_methods.rb
@@ -28,7 +28,7 @@ module Service
         withdrawal_day_of_month: params[:withdrawal_day_of_month],
         closing_day_of_month: params[:closing_day_of_month] || 0
       )
-      raise Exceptions::InvalidArgument, "missing required fields: #{dto.invalid_members.join(', ')}" unless dto.valid?
+      dto.validate!
 
       DB::Repository::PaymentMethod.create(dto)
     end

--- a/api/services/payment_methods.rb
+++ b/api/services/payment_methods.rb
@@ -28,7 +28,7 @@ module Service
         withdrawal_day_of_month: params[:withdrawal_day_of_month],
         closing_day_of_month: params[:closing_day_of_month] || 0
       )
-      raise Exceptions::InvalidArgument unless dto.valid?
+      raise Exceptions::InvalidArgument, "missing required fields: #{dto.invalid_members.join(', ')}" unless dto.valid?
 
       DB::Repository::PaymentMethod.create(dto)
     end

--- a/api/services/records.rb
+++ b/api/services/records.rb
@@ -2,6 +2,7 @@
 
 require "constants"
 require "db/repositories"
+require "lib/exceptions"
 require "lib/id"
 require "lib/finance_record_formatter"
 
@@ -32,7 +33,7 @@ module Service
         date: params[:date],
         encrypted_description: @uhash.encrypt(params[:description])
       )
-      raise StandardError unless dto.valid? # TODO: ちゃんとした Exception を作る
+      raise Exceptions::InvalidArgument, "missing required fields: #{dto.invalid_members.join(', ')}" unless dto.valid?
 
       DB::Repository::FinanceRecord.create(dto)
     end

--- a/api/services/records.rb
+++ b/api/services/records.rb
@@ -33,7 +33,7 @@ module Service
         date: params[:date],
         encrypted_description: @uhash.encrypt(params[:description])
       )
-      raise Exceptions::InvalidArgument, "missing required fields: #{dto.invalid_members.join(', ')}" unless dto.valid?
+      dto.validate!
 
       DB::Repository::FinanceRecord.create(dto)
     end

--- a/api/spec/api/v1/categories_spec.rb
+++ b/api/spec/api/v1/categories_spec.rb
@@ -37,5 +37,10 @@ RSpec.describe "Categories API" do
       expect(labels).to include("New")
       expect(labels).not_to include("Old")
     end
+
+    it "returns 404 when updating a non-existent category" do
+      put "/api/v1/categories/does_not_exist", { id: "does_not_exist", label: "X" }, auth_header
+      expect(last_response.status).to eq(404)
+    end
   end
 end

--- a/api/spec/api/v1/invoice_records_spec.rb
+++ b/api/spec/api/v1/invoice_records_spec.rb
@@ -33,5 +33,28 @@ RSpec.describe "InvoiceRecords API" do
       expect(json_body[:status]).to eq("success")
       expect(json_body[:id]).to eq(id)
     end
+
+    it "returns 404 when updating a non-existent invoice record" do
+      put "/api/v1/invoice_records/does_not_exist",
+          { id: "does_not_exist", amount: 8000, state_id: 1, withdrawal_date: "2026-05-27" },
+          auth_header
+      expect(last_response.status).to eq(404)
+    end
+  end
+
+  describe "DELETE /api/v1/invoice_records/:id" do
+    it "deletes an existing invoice record" do
+      post "/api/v1/invoice_records", invoice_record_params, auth_header
+      id = json_body[:id]
+
+      delete "/api/v1/invoice_records/#{id}", {}, auth_header
+      expect(last_response.status).to eq(200)
+      expect(json_body[:status]).to eq("success")
+    end
+
+    it "returns 404 when deleting a non-existent invoice record" do
+      delete "/api/v1/invoice_records/does_not_exist", {}, auth_header
+      expect(last_response.status).to eq(404)
+    end
   end
 end

--- a/api/spec/lib/exceptions_spec.rb
+++ b/api/spec/lib/exceptions_spec.rb
@@ -22,6 +22,35 @@ RSpec.describe Exceptions do
     end
   end
 
+  describe "http_status mapping" do
+    it "maps InternalServerError to 500" do
+      expect(Exceptions::InternalServerError.http_status).to eq(500)
+    end
+
+    it "maps InvalidArgument to 422" do
+      expect(Exceptions::InvalidArgument.http_status).to eq(422)
+    end
+
+    it "maps NotFound to 404" do
+      expect(Exceptions::NotFound.http_status).to eq(404)
+    end
+
+    it "maps Unauthorized to 401" do
+      expect(Exceptions::Unauthorized.http_status).to eq(401)
+    end
+
+    it "exposes http_status on instances" do
+      expect(Exceptions::NotFound.new("x").http_status).to eq(404)
+    end
+
+    it "all exceptions inherit from Exceptions::Base" do
+      [Exceptions::InternalServerError, Exceptions::InvalidArgument,
+       Exceptions::NotFound, Exceptions::Unauthorized].each do |klass|
+        expect(klass.ancestors).to include(Exceptions::Base)
+      end
+    end
+  end
+
   describe "raise behavior" do
     it "can be raised with a message" do
       expect { raise Exceptions::NotFound, "missing" }


### PR DESCRIPTION
# What

API のエラーハンドリングを統一し、リポジトリ層・サービス層の重複を整理する。

# Changes

- (refactor): Exceptions::Base に http_status を持たせ rescue_from で一括 HTTP マッピング (500/422/404/401)
- (fix): リポジトリ update/delete が ID 不在時 404 を返すよう修正 (旧: 500/NoMethodError)
- (refactor): create/update/delete の重複を Creatable / Updatable / SoftDeletable mixin に集約
- (refactor): DTO バリデーションを DTO#validate! に移し、各 create サービスを 1 行化
- (test): http_status マッピングと 404 挙動の spec を追加

Closes: #41
Closes: #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)