### PR TITLE
refactor: dedupe FinanceRecord query formatting and date filters

### DIFF
--- a/api/db/repositories.rb
+++ b/api/db/repositories.rb
@@ -47,6 +47,29 @@ module DB
       end
       private_class_method :model
 
+      # to_dto.to_h merged with the eager-loaded encrypted category/payment labels.
+      def self.with_encrypted_labels(record)
+        model.to_dto(record).to_h.merge(
+          encrypted_category: record.category&.encrypted_label,
+          encrypted_payment_method: record.payment_method&.encrypted_label
+        )
+      end
+      private_class_method :with_encrypted_labels
+
+      # Apply a begin/end date filter, where either bound is optional.
+      def self.apply_date_range(query, begin_date:, end_date:)
+        if begin_date && end_date
+          query.where(date: begin_date..end_date)
+        elsif begin_date
+          query.where("date >= ?", begin_date)
+        elsif end_date
+          query.where("date <= ?", end_date)
+        else
+          query
+        end
+      end
+      private_class_method :apply_date_range
+
       def self.get_page(
         hashed_user_id:,
         begin_date: Date.today.beginning_of_month,
@@ -56,14 +79,7 @@ module DB
         records = model.eager_load(:category, :payment_method)
                        .where(deleted_at: nil, date: begin_date..end_date, hashed_user_id:)
                        .order(sort).page(page).per(per_page)
-        records.map do |record|
-          model.to_dto(record).to_h.merge(
-            {
-              encrypted_category: record.category&.encrypted_label,
-              encrypted_payment_method: record.payment_method&.encrypted_label
-            }
-          )
-        end
+        records.map { |record| with_encrypted_labels(record) }
       end
 
       def self.get_aggregated_by_category(
@@ -73,14 +89,7 @@ module DB
       )
         query = model.left_joins(:category)
                      .where(deleted_at: nil, hashed_user_id:)
-
-        if begin_date && end_date
-          query = query.where(date: begin_date..end_date)
-        elsif begin_date
-          query = query.where("date >= ?", begin_date)
-        elsif end_date
-          query = query.where("date <= ?", end_date)
-        end
+        query = apply_date_range(query, begin_date:, end_date:)
 
         query.group("finance_records.category_id")
              .select(
@@ -107,23 +116,9 @@ module DB
       )
         query = model.eager_load(:payment_method, :category)
                      .where(deleted_at: nil, hashed_user_id:, category_id:)
+        query = apply_date_range(query, begin_date:, end_date:)
 
-        if begin_date && end_date
-          query = query.where(date: begin_date..end_date)
-        elsif begin_date
-          query = query.where("date >= ?", begin_date)
-        elsif end_date
-          query = query.where("date <= ?", end_date)
-        end
-
-        query.map do |record|
-          model.to_dto(record).to_h.merge(
-            {
-              encrypted_payment_method: record.payment_method&.encrypted_label,
-              encrypted_category: record.category&.encrypted_label
-            }
-          )
-        end
+        query.map { |record| with_encrypted_labels(record) }
       end
 
       # Invoice Records用：指定支払い方法の締め期間内すべてのレコードを取得
@@ -144,14 +139,7 @@ module DB
                        date: begin_date..end_date
                      )
 
-        query.map do |record|
-          model.to_dto(record).to_h.merge(
-            {
-              encrypted_payment_method: record.payment_method&.encrypted_label,
-              encrypted_category: record.category&.encrypted_label
-            }
-          )
-        end
+        query.map { |record| with_encrypted_labels(record) }
       end
     end
 


### PR DESCRIPTION
# What

issue #47 の残項目（eager_load 後の整形ロジック重複・日付範囲フィルタ重複）を解消する。update/delete の重複は #68 で対応済み。

# Changes

- (refactor): to_dto.to_h.merge(encrypted labels) の重複を private helper with_encrypted_labels に集約（get_page / get_records_by_category / get_withdrawal_records_for_invoice）
- (refactor): begin/end の where 分岐を apply_date_range に集約（get_aggregated_by_category / get_records_by_category）

出力キーは不変（merge のキー順のみ変化、JSON serializer は順序非依存）。

Closes: #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)