### PR TITLE
refactor: extract Service::Base for shared init and CRUD flow

### DIFF
--- a/api/services/base.rb
+++ b/api/services/base.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "lib/user_hash"
+
+module Service
+  # Base class for service objects. Sets up the per-user encryption context
+  # (@uhash / @hashed_uid) shared by every service, and provides the common
+  # create/delete flow on top of each service's repository.
+  class Base
+    def initialize(uid:)
+      @uhash = UserHash.new(uid)
+      @hashed_uid = @uhash.user_hash
+    end
+
+    private
+
+    # The DB::Repository class this service persists through. Subclasses override.
+    def repository
+      raise NotImplementedError, "#{self.class} must implement #repository"
+    end
+
+    # Validate a freshly built DTO and create the record.
+    def persist(dto)
+      dto.validate!
+      repository.create(dto)
+    end
+
+    # Soft-delete by id through the repository.
+    def destroy(id:)
+      repository.delete(id:)
+    end
+  end
+end

--- a/api/services/categories.rb
+++ b/api/services/categories.rb
@@ -5,12 +5,12 @@ require "db/repositories"
 require "lib/category_formatter"
 require "lib/exceptions"
 require "lib/id"
+require "services/base"
 
 module Service
-  class Categories
+  class Categories < Base
     def initialize(uid:)
-      @uhash = UserHash.new(uid)
-      @hashed_uid = @uhash.user_hash
+      super
       @formatter = CategoryFormatter.new(uhash: @uhash)
     end
 
@@ -26,9 +26,7 @@ module Service
         hashed_user_id: @hashed_uid,
         encrypted_label: @uhash.encrypt(params[:label])
       )
-      dto.validate!
-
-      DB::Repository::Category.create(dto)
+      persist(dto)
     end
 
     def update(id:, params:)
@@ -39,5 +37,9 @@ module Service
 
       DB::Repository::Category.update(id:, params: params_dto)
     end
+
+    private
+
+    def repository = DB::Repository::Category
   end
 end

--- a/api/services/invoice_records.rb
+++ b/api/services/invoice_records.rb
@@ -7,12 +7,12 @@ require "lib/exceptions"
 require "lib/finance_record_formatter"
 require "lib/id"
 require "lib/invoice_record_formatter"
+require "services/base"
 
 module Service
-  class InvoiceRecords
+  class InvoiceRecords < Base
     def initialize(uid:)
-      @uhash = UserHash.new(uid)
-      @hashed_uid = @uhash.user_hash
+      super
       @formatter = FinanceRecordFormatter.new(uhash: @uhash)
       @invoice_formatter = InvoiceRecordFormatter.new(uhash: @uhash)
     end
@@ -26,9 +26,7 @@ module Service
         payment_method_id: params[:payment_method_id],
         withdrawal_date: params[:withdrawal_date]
       )
-      dto.validate!
-
-      DB::Repository::InvoiceRecord.create(dto)
+      persist(dto)
     end
 
     def update(id:, params:)
@@ -43,7 +41,7 @@ module Service
     end
 
     def delete(id:)
-      DB::Repository::InvoiceRecord.delete(id:)
+      destroy(id:)
     end
 
     def monthly_records(year: nil, month: nil)
@@ -113,6 +111,8 @@ module Service
     end
 
     private
+
+    def repository = DB::Repository::InvoiceRecord
 
     def calc_withdrawal_date(year, month, day_of_month)
       begin

--- a/api/services/payment_methods.rb
+++ b/api/services/payment_methods.rb
@@ -5,12 +5,12 @@ require "db/repositories"
 require "lib/exceptions"
 require "lib/id"
 require "lib/payment_method_formatter"
+require "services/base"
 
 module Service
-  class PaymentMethods
+  class PaymentMethods < Base
     def initialize(uid:)
-      @uhash = UserHash.new(uid)
-      @hashed_uid = @uhash.user_hash
+      super
       @formatter = PaymentMethodFormatter.new(uhash: @uhash)
     end
 
@@ -28,9 +28,7 @@ module Service
         withdrawal_day_of_month: params[:withdrawal_day_of_month],
         closing_day_of_month: params[:closing_day_of_month] || 0
       )
-      dto.validate!
-
-      DB::Repository::PaymentMethod.create(dto)
+      persist(dto)
     end
 
     def update(id:, params:)
@@ -43,5 +41,9 @@ module Service
 
       DB::Repository::PaymentMethod.update(id:, params: params_dto)
     end
+
+    private
+
+    def repository = DB::Repository::PaymentMethod
   end
 end

--- a/api/services/records.rb
+++ b/api/services/records.rb
@@ -5,12 +5,12 @@ require "db/repositories"
 require "lib/exceptions"
 require "lib/id"
 require "lib/finance_record_formatter"
+require "services/base"
 
 module Service
-  class FinanceRecords
+  class FinanceRecords < Base
     def initialize(uid:)
-      @uhash = UserHash.new(uid)
-      @hashed_uid = @uhash.user_hash
+      super
       @formatter = FinanceRecordFormatter.new(uhash: @uhash)
     end
 
@@ -33,9 +33,7 @@ module Service
         date: params[:date],
         encrypted_description: @uhash.encrypt(params[:description])
       )
-      dto.validate!
-
-      DB::Repository::FinanceRecord.create(dto)
+      persist(dto)
     end
 
     def update(id:, params:)
@@ -55,7 +53,11 @@ module Service
     end
 
     def delete(id:)
-      DB::Repository::FinanceRecord.delete(id:)
+      destroy(id:)
     end
+
+    private
+
+    def repository = DB::Repository::FinanceRecord
   end
 end

--- a/api/services/view.rb
+++ b/api/services/view.rb
@@ -3,12 +3,12 @@
 require "constants"
 require "db/repositories"
 require "lib/finance_record_formatter"
+require "services/base"
 
 module Service
-  class View
+  class View < Base
     def initialize(uid:)
-      @uhash = UserHash.new(uid)
-      @hashed_uid = @uhash.user_hash
+      super
       @formatter = FinanceRecordFormatter.new(uhash: @uhash)
     end
 


### PR DESCRIPTION
# What

サービス層の初期化・CRUD パターン重複を Service::Base に集約する（issue #46）。

# Changes

- (refactor): Service::Base に initialize(uid:) の @uhash / @hashed_uid 生成を集約。各サービスは super 後に formatter のみ生成
- (refactor): private な repository フックと persist(dto)（validate! + create）/ destroy(id:)（delete）ヘルパーを Base に追加し、各サービスの create/delete を経由させる
- (note): update は DTO 構築（暗号化・デフォルト値・nil 処理）がリソースごとに異なるため各サービスに保持

動作不変。テスト緑・RuboCop クリーン確認済み。view.rb の直接 decrypt は本 PR のスコープ外。

Closes: #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)