### PR TITLE
perf: eliminate N+1 queries in category_aggregation

### DIFF
--- a/api/db/repositories/finance_records.rb
+++ b/api/db/repositories/finance_records.rb
@@ -50,40 +50,13 @@ module DB
         records.map { |record| with_encrypted_labels(record) }
       end
 
-      def self.get_aggregated_by_category(
+      def self.get_all_by_user(
         hashed_user_id:,
-        begin_date: nil,
-        end_date: nil
-      )
-        query = model.left_joins(:category)
-                     .where(deleted_at: nil, hashed_user_id:)
-        query = apply_date_range(query, begin_date:, end_date:)
-
-        query.group("finance_records.category_id")
-             .select(
-               "finance_records.category_id",
-               "categories.encrypted_label as encrypted_category",
-               "SUM(finance_records.amount) as total_amount",
-               "COUNT(*) as record_count"
-             )
-             .map do |record|
-               {
-                 category_id: record.category_id,
-                 encrypted_category: record.encrypted_category,
-                 total_amount: record.total_amount.to_i,
-                 record_count: record.record_count
-               }
-             end
-      end
-
-      def self.get_records_by_category(
-        hashed_user_id:,
-        category_id:,
         begin_date: nil,
         end_date: nil
       )
         query = model.eager_load(:payment_method, :category)
-                     .where(deleted_at: nil, hashed_user_id:, category_id:)
+                     .where(deleted_at: nil, hashed_user_id:)
         query = apply_date_range(query, begin_date:, end_date:)
 
         query.map { |record| with_encrypted_labels(record) }

--- a/api/services/view.rb
+++ b/api/services/view.rb
@@ -14,33 +14,27 @@ module Service
 
     def category_aggregation(begin_date: nil, end_date: nil)
       opts = { hashed_user_id: @hashed_uid, begin_date:, end_date: }.compact
-      aggregated_records = DB::Repository::FinanceRecord.get_aggregated_by_category(**opts)
+      all_records = DB::Repository::FinanceRecord.get_all_by_user(**opts)
 
-      aggregated_records.map do |aggregated_record|
-        category = if aggregated_record[:category_id] == Constants::TODO_ID[:category] ||
-                      aggregated_record[:encrypted_category].nil?
+      grouped = all_records.group_by do |r|
+        r[:category_id] || Constants::TODO_ID[:category]
+      end
+
+      grouped.map do |category_id, records|
+        sample = records.first
+        category = if category_id == Constants::TODO_ID[:category] ||
+                      sample[:encrypted_category].nil?
                      "TODO"
                    else
-                     @uhash.decrypt(aggregated_record[:encrypted_category])
+                     @uhash.decrypt(sample[:encrypted_category])
                    end
 
-        actual_category_id = aggregated_record[:category_id] || Constants::TODO_ID[:category]
-
-        detail_records = DB::Repository::FinanceRecord.get_records_by_category(
-          hashed_user_id: @hashed_uid,
-          category_id: actual_category_id,
-          begin_date: opts[:begin_date],
-          end_date: opts[:end_date]
-        )
-
-        records = detail_records.map { @formatter.format(it) }
-
         {
-          category_id: actual_category_id,
+          category_id:,
           category:,
-          total_amount: aggregated_record[:total_amount],
-          record_count: aggregated_record[:record_count],
-          records: records
+          total_amount: records.sum { it[:amount] },
+          record_count: records.size,
+          records: records.map { @formatter.format(it) }
         }
       end
     end


### PR DESCRIPTION
# What

`view/categories/aggregation` でカテゴリ数 N に対して N+1 クエリが発行されていた問題を解消する。

# Changes

- (perf): `get_aggregated_by_category` と `get_records_by_category` を廃止し、`get_all_by_user` に統合
- (refactor): `Service::View#category_aggregation` でインメモリグルーピング・集計に変更（クエリ数: N+1 → 1）

Closes: #54