### PR TITLE
fix: remove encrypted payment_method from invoice repo and guard nil encrypt in update

### DIFF
--- a/api/db/repositories/invoice_records.rb
+++ b/api/db/repositories/invoice_records.rb
@@ -21,19 +21,12 @@ module DB
       end
 
       def self.monthly_records(hashed_user_id:, year:, month:)
-        records = model.eager_load(:payment_method)
-                       .where(
-                         deleted_at: nil,
-                         hashed_user_id:,
-                         withdrawal_date: Date.new(year, month)..Date.new(year, month).end_of_month
-                       )
-        records.map do |record|
-          model.to_dto(record).to_h.merge(
-            {
-              payment_method: record.payment_method&.encrypted_label
-            }
-          )
-        end
+        records = model.where(
+          deleted_at: nil,
+          hashed_user_id:,
+          withdrawal_date: Date.new(year, month)..Date.new(year, month).end_of_month
+        )
+        records.map { |record| model.to_dto(record).to_h }
       end
     end
   end

--- a/api/services/records.rb
+++ b/api/services/records.rb
@@ -39,13 +39,13 @@ module Service
     def update(id:, params:)
       params_dto = DB::Model::FinanceRecord.dto.new(
         record_type_id: params[:record_type_id],
-        encrypted_title: @uhash.encrypt(params[:title]),
+        encrypted_title: params[:title]&.present? ? @uhash.encrypt(params[:title]) : nil,
         amount: params[:amount],
         category_id: params[:category_id],
         payment_method_id: params[:payment_method_id],
         state_id: params[:state_id],
         date: params[:date],
-        encrypted_description: @uhash.encrypt(params[:description])
+        encrypted_description: params[:description]&.present? ? @uhash.encrypt(params[:description]) : nil
       ).to_h.compact
       raise Exceptions::InvalidArgument, "no params to update" if params_dto.empty?
 


### PR DESCRIPTION
# What

- `InvoiceRecord.monthly_records` がリポジトリ層で `payment_method: encrypted_label` を暗号化済みのままハッシュに混入させており、サービス層の戻り値に平文と暗号化値が同居する状態だった (#44)
- `Service::FinanceRecords#update` で nil パラメータに対しても `@uhash.encrypt(nil)` を無条件に呼んでいたため、未指定フィールドが空文字暗号化値で上書きされるリスクがあった (#43)

# Changes

- (fix): `InvoiceRecord.monthly_records` から不要な `eager_load(:payment_method)` と暗号化済み `payment_method` キーのマージを削除
- (fix): `Service::FinanceRecords#update` の暗号化フィールドに `&.present?` ガードを追加

Closes: #44
Closes: #43