### PR TITLE
fix: gate auth bypass behind DEV_UID env var

### DIFF
--- a/api/app/api/root.rb
+++ b/api/app/api/root.rb
@@ -5,7 +5,7 @@ require "lib/exceptions"
 require "lib/firebase"
 require "grape-swagger"
 require "grape-swagger-entity"
-require_relative "./v1/root"
+require_relative "v1/root"
 
 module API
   class Root < Grape::API
@@ -22,14 +22,22 @@ module API
 
       def request_bearer
         b = authorization_header&.gsub("Bearer ", "")
-        return Constants::EXAMPLE_USER_UID if b.blank?
+        if b.blank?
+          raise Exceptions::Unauthorized, "Unauthorized" unless Envs::DEV_UID
+
+          return Envs::DEV_UID
+        end
 
         b
       end
 
       def request_userdata
         jwt = authorization_header&.gsub("Bearer ", "")
-        return { uid: Constants::EXAMPLE_USER_UID } if jwt.blank?
+        if jwt.blank?
+          raise Exceptions::Unauthorized, "Unauthorized" unless Envs::DEV_UID
+
+          return { uid: Envs::DEV_UID }
+        end
 
         # JWT failures raise Exceptions::Unauthorized / InternalServerError,
         # which rescue_from maps to the right HTTP status.

--- a/api/envs.rb
+++ b/api/envs.rb
@@ -6,4 +6,5 @@ module Envs
   DB_USER = ENV.fetch("DB_USER", "app_user")
   DB_PASSWORD = ENV.fetch("DB_PASSWORD", "password")
   DB_PORT = ENV.fetch("DB_PORT", "3306")
+  DEV_UID = ENV.fetch("DEV_UID", nil)
 end


### PR DESCRIPTION
# What

Authorization ヘッダが空のとき固定の EXAMPLE_USER_UID にフォールバックして誰でも API アクセスできる認証バイパスがあった。本番では 401 を返し、開発時のみ DEV_UID 環境変数で任意の UID を注入できるよう修正する。

# Changes

- (fix): request_userdata/request_bearer で DEV_UID 未設定時は Unauthorized を raise
- (feat): api/envs.rb に DEV_UID 環境変数を追加

Closes: #34