### PR TITLE
fix: upgrade encryption to AES-256-GCM with random IV and env-backed salts

### DIFF
--- a/api/constants.rb
+++ b/api/constants.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "envs"
+
 module Constants
   RECORD_STATES = [
     { id: 0, label: "予定" },
@@ -31,10 +33,9 @@ module Constants
 
   HASH = {
     user_infromation_salt: "userinfo",
-    user_salt: "user",
-    algorithm: "aes-256-cbc",
-    fixed_salt: "fixedsalt123456",
-    fixed_iv: "fixediv123456789"
+    user_salt: Envs::USER_SALT,
+    algorithm: "aes-256-gcm",
+    fixed_salt: Envs::FIXED_SALT
   }.freeze
 
   EXAMPLE_USER_UID = "example_user_uid"

--- a/api/envs.rb
+++ b/api/envs.rb
@@ -6,4 +6,6 @@ module Envs
   DB_USER = ENV.fetch("DB_USER", "app_user")
   DB_PASSWORD = ENV.fetch("DB_PASSWORD", "password")
   DB_PORT = ENV.fetch("DB_PORT", "3306")
+  USER_SALT = ENV.fetch("USER_SALT", "dev_user_salt_placeholder")
+  FIXED_SALT = ENV.fetch("FIXED_SALT", "dev_fixed_salt_placeholder")
 end

--- a/api/lib/user_hash.rb
+++ b/api/lib/user_hash.rb
@@ -19,6 +19,8 @@ class UserHash
     @user_info_hash ||= Digest::SHA256.hexdigest(@base_uid + Constants::HASH[:user_infromation_salt])[0..23]
   end
 
+  # Encrypted data layout (Base64-encoded):
+  #   [IV: 12 bytes] + [ciphertext: N bytes] + [GCM auth_tag: 16 bytes]
   def encrypt(data)
     cipher = OpenSSL::Cipher.new(Constants::HASH[:algorithm])
     cipher.encrypt

--- a/api/lib/user_hash.rb
+++ b/api/lib/user_hash.rb
@@ -23,15 +23,23 @@ class UserHash
     cipher = OpenSSL::Cipher.new(Constants::HASH[:algorithm])
     cipher.encrypt
     cipher.key = @key
-    cipher.iv = Constants::HASH[:fixed_iv]
-    Base64.strict_encode64(cipher.update(data) + cipher.final)
+    iv = OpenSSL::Random.random_bytes(12)
+    cipher.iv = iv
+    ciphertext = cipher.update(data) + cipher.final
+    auth_tag = cipher.auth_tag
+    Base64.strict_encode64(iv + ciphertext + auth_tag)
   end
 
   def decrypt(base64_data)
+    raw = Base64.decode64(base64_data)
+    iv = raw[0, 12]
+    auth_tag = raw[-16, 16]
+    ciphertext = raw[12, raw.bytesize - 28]
     cipher = OpenSSL::Cipher.new(Constants::HASH[:algorithm])
     cipher.decrypt
     cipher.key = @key
-    cipher.iv = Constants::HASH[:fixed_iv]
-    cipher.update(Base64.decode64(base64_data)) + cipher.final
+    cipher.iv = iv
+    cipher.auth_tag = auth_tag
+    cipher.update(ciphertext) + cipher.final
   end
 end


### PR DESCRIPTION
# What

AES-256-CBC + 固定 IV の組み合わせにより同一平文が常に同一暗号文になる（決定論的暗号化）問題、および改ざん検知なし（MAC/AEAD 不使用）、ソルト値のハードコードの 3 点を一括修正する。既存暗号化データは再暗号化不可（データリセット許容済み）。

# Changes

- (fix): AES-256-GCM（AEAD）へ移行、encrypt ごとにランダム IV を生成
- (fix): user_salt / fixed_salt を環境変数経由に変更
- (fix): constants.rb から fixed_iv を削除

Closes: #35
Closes: #36
Closes: #38