### PR TITLE
fix: correct JWT payload/header variable naming in firebase.rb

### DIFF
--- a/api/lib/firebase.rb
+++ b/api/lib/firebase.rb
@@ -30,13 +30,13 @@ class Firebase
     end
 
     def decode_jwt(jwt)
-      payload = JWT.decode(jwt, nil, true, { algorithm: "RS256", jwks: jwks })
-      header = payload[0]
+      decoded = JWT.decode(jwt, nil, true, { algorithm: "RS256", jwks: jwks })
+      payload = decoded[0]
 
-      raise JWT::DecodeError.exception("aud not match") if header["aud"] != "temama-finascope"
-      raise JWT::DecodeError.exception("iss not match") if header["iss"] != "https://securetoken.google.com/temama-finascope"
+      raise JWT::DecodeError.exception("aud not match") if payload["aud"] != "temama-finascope"
+      raise JWT::DecodeError.exception("iss not match") if payload["iss"] != "https://securetoken.google.com/temama-finascope"
 
-      { uid: header["user_id"], name: header["name"], picture_url: header["picture"] }
+      { uid: payload["user_id"], name: payload["name"], picture_url: payload["picture"] }
     rescue JWT::DecodeError => e
       raise Exceptions::Unauthorized, "failed to decode JWT: #{e}"
     end


### PR DESCRIPTION
# What

firebase.rb で JWT.decode の戻り値 [0]（payload）を header という変数名で受け取っており、コードの読解を困難にしていた。実際のクレーム検証（aud/iss）は payload を正しく参照できていたが、変数名の乖離がバグリスクを高めていた。

# Changes

- (fix): payload/header の変数名を実際の内容に合わせて修正

Closes: #37