### PR TITLE
fix: remove puts params.inspect and redirect debug output to stderr

### DIFF
--- a/api/app/api/v1/invoice_records.rb
+++ b/api/app/api/v1/invoice_records.rb
@@ -42,8 +42,6 @@ module API
           requires :payment_method_id, type: String, desc: "(String) Payment method ID"
         end
         post do
-          puts params.inspect
-
           uid = request_userdata[:uid]
           invoice_records_service = Service::InvoiceRecords.new(uid:)
           record = invoice_records_service.create(

--- a/api/lib/firebase.rb
+++ b/api/lib/firebase.rb
@@ -17,14 +17,14 @@ class Firebase
     def jwks
       return @jwks if @jwks && !jwks_expired?
 
-      puts "downloading Firebase jwk..."
+      $stderr.puts "downloading Firebase jwk..."
       url = "https://www.googleapis.com/service_accounts/v1/jwk/securetoken@system.gserviceaccount.com"
       res = Net::HTTP.get_response(URI.parse(url))
-      puts res.inspect
+      $stderr.puts res.inspect
       raise Exceptions::InternalServerError, "failed to download Firebase jwk" if res.code != "200"
 
       @expires_at = Time.now + 3600 # 1 hour
-      puts "expires at: #{@expires_at}"
+      $stderr.puts "expires at: #{@expires_at}"
 
       @jwks = JSON.parse(res.body)
     end

--- a/api/lib/firebase.rb
+++ b/api/lib/firebase.rb
@@ -17,14 +17,14 @@ class Firebase
     def jwks
       return @jwks if @jwks && !jwks_expired?
 
-      $stderr.puts "downloading Firebase jwk..."
+      warn "downloading Firebase jwk..."
       url = "https://www.googleapis.com/service_accounts/v1/jwk/securetoken@system.gserviceaccount.com"
       res = Net::HTTP.get_response(URI.parse(url))
-      $stderr.puts res.inspect
+      warn res.inspect
       raise Exceptions::InternalServerError, "failed to download Firebase jwk" if res.code != "200"
 
       @expires_at = Time.now + 3600 # 1 hour
-      $stderr.puts "expires at: #{@expires_at}"
+      warn "expires at: #{@expires_at}"
 
       @jwks = JSON.parse(res.body)
     end


### PR DESCRIPTION
# What

invoice_records.rb に残存していた `puts params.inspect` がリクエストパラメータ（金額・payment_method_id 等）を平文で標準出力に流していた。その他の `puts` も本番ログ管理（マスキング・ローテーション・レベル分け）を回避する問題があった。

# Changes

- (fix): invoice_records.rb の `puts params.inspect` を削除
- (fix): firebase.rb の診断出力を `warn` に変更

Closes: #39