### PR TITLE
fix: implement hashed_user_id and key column indexes

### DIFF
--- a/api/db/models.rb
+++ b/api/db/models.rb
@@ -32,9 +32,15 @@ module DB
         t_def.timestamps null: false
       end
 
-      # TODO: add_index, remove_index に対応する
+      # define_index: returns index definitions for ActiveRecord::Schema.define
+      # Each hash: { columns:, name:, unique: }
       def self.define_index
-        [{}]
+        [
+          { columns: [:hashed_user_id], name: "index_finance_records_on_hashed_user_id" },
+          { columns: [:category_id], name: "index_finance_records_on_category_id" },
+          { columns: [:payment_method_id], name: "index_finance_records_on_payment_method_id" },
+          { columns: [:date], name: "index_finance_records_on_date" }
+        ]
       end
     end
 
@@ -50,6 +56,13 @@ module DB
 
         t_def.datetime :deleted_at, null: true
         t_def.timestamps null: false
+      end
+
+      # define_index: returns index definitions for ActiveRecord::Schema.define
+      def self.define_index
+        [
+          { columns: [:hashed_user_id], name: "index_categories_on_hashed_user_id" }
+        ]
       end
     end
 
@@ -75,6 +88,13 @@ module DB
         t_def.datetime :deleted_at, null: true
         t_def.timestamps null: false
       end
+
+      # define_index: returns index definitions for ActiveRecord::Schema.define
+      def self.define_index
+        [
+          { columns: [:hashed_user_id], name: "index_payment_methods_on_hashed_user_id" }
+        ]
+      end
     end
 
     class InvoiceRecord < DB::Model::BaseWrapper
@@ -92,7 +112,15 @@ module DB
 
         t_def.datetime :deleted_at, null: true
         t_def.timestamps null: false
-        # TODO: payment_method_id_withdrawal_day_index UNIQUE
+      end
+
+      # define_index: returns index definitions for ActiveRecord::Schema.define
+      def self.define_index
+        [
+          { columns: [:hashed_user_id], name: "index_invoice_records_on_hashed_user_id" },
+          { columns: [:payment_method_id], name: "index_invoice_records_on_payment_method_id" },
+          { columns: [:withdrawal_date], name: "index_invoice_records_on_withdrawal_date" }
+        ]
       end
     end
 

--- a/api/scripts/create_database.rb
+++ b/api/scripts/create_database.rb
@@ -42,6 +42,23 @@ def check_schema(model_class)
   true
 end
 
+def apply_indexes(model_class)
+  return unless model_class.respond_to?(:define_index)
+
+  model_class.define_index.each do |index_def|
+    next if index_def.empty?
+
+    columns = index_def[:columns]
+    opts = {}
+    opts[:name] = index_def[:name] if index_def[:name]
+    opts[:unique] = index_def[:unique] if index_def[:unique]
+
+    add_index model_class.table_name, columns, **opts
+  rescue ArgumentError => e
+    puts "Index already exists or error: #{e.message}"
+  end
+end
+
 def apply_table(model_class, force: false)
   table_name = model_class.table_name
 
@@ -78,6 +95,7 @@ ActiveRecord::Schema.define do
       $stdin.gets.chomp
       apply_table(model_class, force: true)
     end
+    apply_indexes(model_class)
     puts
   end
 end


### PR DESCRIPTION
# What

ほぼ全クエリで絞り込みに使う `hashed_user_id` にインデックスがなく、データ量増加時にフルスキャンになる問題があった。`define_index` メソッドがプレースホルダ `[{}]` のままで一切インデックスが定義されていなかった。

# Changes

- (fix): 各モデル（FinanceRecord / Category / PaymentMethod / InvoiceRecord）の `define_index` にインデックス定義を実装
- (fix): `create_database.rb` でインデックス定義を適用するよう更新

Closes: #55