### PR TITLE
chore: make feature name field optional in feature issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-ddoc.yml
+++ b/.github/ISSUE_TEMPLATE/feature-ddoc.yml
@@ -41,10 +41,10 @@ body:
     id: feature_name
     attributes:
       label: 機能名（英語スネークケース）
-      description: Design Doc のファイル名に使う短い識別子。`docs/design-doc/[連番]-[scope]-[ここ].md` の `ここ` に入る。
+      description: Design Doc のファイル名に使う短い識別子。`docs/design-doc/[連番]-[scope]-[ここ].md` の `ここ` に入る。空欄の場合はおまかせ。
       placeholder: 例）bulk-delete-records
     validations:
-      required: true
+      required: false
 
   - type: textarea
     id: goals


### PR DESCRIPTION
# What

feature issue テンプレートの「機能名（英語スネークケース）」フィールドが required になっていて、空欄のまま issue を作れなかった。おまかせにしたい場合に入力が強制されるのが不便だった。

# Changes

- (chore): feature-ddoc.yml の `feature_name` フィールドを `required: false` に変更
- (chore): description に「空欄の場合はおまかせ」を追記