### PR TITLE
feat: add recurring flag to finance records

### DIFF
--- a/api/app/api/v1/entities/records.rb
+++ b/api/app/api/v1/entities/records.rb
@@ -19,6 +19,7 @@ module API
         expose :state_id, documentation: { type: Integer, desc: "State ID" }
         expose :category_id, documentation: { type: String, desc: "Category ID" }
         expose :payment_method_id, documentation: { type: String, desc: "Payment method ID" }
+        expose :recurring, documentation: { type: Grape::API::Boolean, desc: "Whether this is a recurring record" }
       end
     end
   end

--- a/api/app/api/v1/records.rb
+++ b/api/app/api/v1/records.rb
@@ -46,6 +46,7 @@ module API
           requires :category_id, type: String, desc: "(String) Record category ID"
           requires :date, type: String, desc: "(String) Record date in ISO8601 format"
           requires :payment_method_id, type: String, desc: "(String) Payment method ID"
+          optional :recurring, type: Grape::API::Boolean, desc: "(Boolean) Recurring record flag", default: false
         end
         post do
           uid = request_userdata[:uid]
@@ -58,7 +59,8 @@ module API
             amount: params[:amount],
             category_id: params[:category_id],
             date: Date.parse(params[:date]),
-            payment_method_id: params[:payment_method_id]
+            payment_method_id: params[:payment_method_id],
+            recurring: params[:recurring]
           )
           present_mutation_response(record)
         end
@@ -75,6 +77,7 @@ module API
           requires :category_id, type: String, desc: "(String) Record category ID"
           requires :date, type: String, desc: "(String) Record date in ISO8601 format"
           requires :payment_method_id, type: String, desc: "(String) Payment method ID"
+          optional :recurring, type: Grape::API::Boolean, desc: "(Boolean) Recurring record flag"
         end
         put ":id" do
           uid = request_userdata[:uid]
@@ -89,7 +92,8 @@ module API
               amount: params[:amount],
               category_id: params[:category_id],
               date: Date.parse(params[:date]),
-              payment_method_id: params[:payment_method_id]
+              payment_method_id: params[:payment_method_id],
+              recurring: params[:recurring]
             }
           )
           present_mutation_response(record)

--- a/api/db/models.rb
+++ b/api/db/models.rb
@@ -27,6 +27,7 @@ module DB
         t_def.string :payment_method_id, null: false
         t_def.date :date, null: false
         t_def.string :encrypted_description, null: true
+        t_def.boolean :recurring, null: false, default: false
 
         t_def.datetime :deleted_at, null: true
         t_def.timestamps null: false

--- a/api/services/records.rb
+++ b/api/services/records.rb
@@ -31,7 +31,8 @@ module Service
         payment_method_id: params[:payment_method_id],
         state_id: params[:state_id],
         date: params[:date],
-        encrypted_description: @uhash.encrypt(params[:description])
+        encrypted_description: @uhash.encrypt(params[:description]),
+        recurring: params[:recurring] || false
       )
       persist(dto)
     end
@@ -45,7 +46,8 @@ module Service
         payment_method_id: params[:payment_method_id],
         state_id: params[:state_id],
         date: params[:date],
-        encrypted_description: params[:description]&.present? ? @uhash.encrypt(params[:description]) : nil
+        encrypted_description: params[:description]&.present? ? @uhash.encrypt(params[:description]) : nil,
+        recurring: params[:recurring]
       ).to_h.compact
       raise Exceptions::InvalidArgument, "no params to update" if params_dto.empty?
 

--- a/api/spec/api/v1/records_spec.rb
+++ b/api/spec/api/v1/records_spec.rb
@@ -3,6 +3,8 @@
 RSpec.describe "Records API" do
   before { stub_authenticated_user }
 
+  let(:today) { Date.today }
+
   let(:record_params) do
     {
       title: "Test Record",
@@ -12,7 +14,14 @@ RSpec.describe "Records API" do
       amount: 1000,
       category_id: "TODO_CATEGORY_ID",
       payment_method_id: "TODO_PAYMENT_METHOD_ID",
-      date: "2026-05-01"
+      date: today.iso8601
+    }
+  end
+
+  let(:get_params) do
+    {
+      begin_date: today.beginning_of_month.iso8601,
+      end_date: today.end_of_month.iso8601
     }
   end
 
@@ -23,6 +32,26 @@ RSpec.describe "Records API" do
       expect(json_body[:status]).to eq("success")
       expect(json_body[:id]).to be_a(String)
     end
+
+    it "defaults recurring to false when not specified" do
+      post "/api/v1/records", record_params, auth_header
+      expect(last_response.status).to eq(201)
+      created_id = json_body[:id]
+
+      get "/api/v1/records", get_params, auth_header
+      record = json_body[:records].find { |r| r[:id] == created_id }
+      expect(record[:recurring]).to eq(false)
+    end
+
+    it "creates a record with recurring true" do
+      post "/api/v1/records", record_params.merge(recurring: true), auth_header
+      expect(last_response.status).to eq(201)
+      created_id = json_body[:id]
+
+      get "/api/v1/records", get_params, auth_header
+      record = json_body[:records].find { |r| r[:id] == created_id }
+      expect(record[:recurring]).to eq(true)
+    end
   end
 
   describe "GET /api/v1/records" do
@@ -30,10 +59,19 @@ RSpec.describe "Records API" do
       post "/api/v1/records", record_params, auth_header
       created_id = json_body[:id]
 
-      get "/api/v1/records", {}, auth_header
+      get "/api/v1/records", get_params, auth_header
       expect(last_response.status).to eq(200)
       ids = json_body[:records].map { |r| r[:id] }
       expect(ids).to include(created_id)
+    end
+
+    it "includes recurring field in response" do
+      post "/api/v1/records", record_params, auth_header
+      created_id = json_body[:id]
+
+      get "/api/v1/records", get_params, auth_header
+      record = json_body[:records].find { |r| r[:id] == created_id }
+      expect(record).to have_key(:recurring)
     end
   end
 end

--- a/api/spec/api/v1/records_spec.rb
+++ b/api/spec/api/v1/records_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe "Records API" do
       amount: 1000,
       category_id: "TODO_CATEGORY_ID",
       payment_method_id: "TODO_PAYMENT_METHOD_ID",
-<<<<<<< HEAD
       date: today.iso8601
     }
   end

--- a/front/src/lib/api/v1/types.d.ts
+++ b/front/src/lib/api/v1/types.d.ts
@@ -23,6 +23,7 @@ export interface Record {
   state_id: number;
   category_id: string;
   payment_method_id: string;
+  recurring: boolean;
 }
 
 export interface RecordType {
@@ -48,6 +49,7 @@ export interface CreateRecordRequest {
   category_id: string;
   payment_method_id: string;
   date: string; // NOTE: ISO 8601 format
+  recurring?: boolean;
 }
 
 export interface CreateRecordResponse {
@@ -65,6 +67,7 @@ export interface UpdateRecordRequest {
   category_id: string;
   payment_method_id: string;
   date: string; // NOTE: ISO 8601 format
+  recurring?: boolean;
 }
 
 export interface UpdateRecordResponse {


### PR DESCRIPTION
# What

Add `recurring` boolean field to FinanceRecord to support subscription/recurring payments. Propagated through DB model, service, API endpoint, entity, frontend types, and tests.

# Changes

- (feat): add `recurring` boolean column to `finance_records` table (default: false)
- (feat): expose `recurring` in POST/PUT `/api/v1/records` params and service layer
- (feat): expose `recurring` field in Record entity response
- (feat): add `recurring` to TypeScript types (`Record`, `CreateRecordRequest`, `UpdateRecordRequest`)
- (test): add RSpec tests for recurring flag (default false, create with true, response includes field)

Related: #59