### PR TITLE
fix: fix records spec date to use current month for CI

### DIFF
--- a/api/spec/api/v1/records_spec.rb
+++ b/api/spec/api/v1/records_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Records API" do
       amount: 1000,
       category_id: "TODO_CATEGORY_ID",
       payment_method_id: "TODO_PAYMENT_METHOD_ID",
-      date: "2026-05-01"
+      date: Date.today.strftime("%Y-%m-01")
     }
   end
 


### PR DESCRIPTION
# What

Fix the `records_spec.rb` test that was failing in CI because the hardcoded date `2026-05-01` fell outside the default GET filter range (current month).

# Changes

- (fix): use `Date.today.strftime("%Y-%m-01")` instead of a hardcoded date in records_spec