### PR TITLE
docs: add design docs for recurring records (issue #59)

### DIFF
--- a/docs/design-doc/0017-api-recurring-records.md
+++ b/docs/design-doc/0017-api-recurring-records.md
@@ -35,7 +35,7 @@ t_def.string  :category_id,        null: false
 t_def.string  :payment_method_id,  null: false
 t_def.string  :encrypted_description, null: true
 t_def.date    :start_date,         null: false  # 繰り返し開始月
-t_def.date    :end_date,           null: true   # 繰り返し終了月 (null: 無期限)
+t_def.integer :total_count,        null: true   # 支払い総回数 (null: 無期限)
 t_def.datetime :deleted_at,        null: true
 t_def.timestamps null: false
 ```
@@ -73,7 +73,7 @@ t_def.string :recurring_group_id, null: true  # recurring_records.id を参照
   "category_id": "cat_xxx",
   "payment_method_id": "pm_xxx",
   "start_date": "2026-06-01",
-  "end_date": null
+  "total_count": null
 }
 ```
 
@@ -90,7 +90,8 @@ t_def.string :recurring_group_id, null: true  # recurring_records.id を参照
       "category": "サブスク",
       "payment_method": "クレジットカード",
       "start_date": "2026-06-01",
-      "end_date": null,
+      "total_count": null,
+      "generated_count": 1,
       "record_type_id": 1,
       "state_id": 1,
       "category_id": "cat_xxx",
@@ -185,4 +186,4 @@ generate エンドポイント内で同月生成済みかを確認する際、DB
 
 ## 未解決事項
 
-- `end_date` を超えた recurring_record の扱い: 生成時にスキップするが、deleted_at を立てるかは今後判断
+- `total_count` に達した recurring_record の扱い: generate 時に 409 を返すが、`deleted_at` を立てるかは今後判断

--- a/docs/design-doc/0017-api-recurring-records.md
+++ b/docs/design-doc/0017-api-recurring-records.md
@@ -137,6 +137,15 @@ GET /api/v1/records?recurring=true
 
 ログイン時の自動生成は行わない。`finance_records` の生成は上記 generate エンドポイントを明示的に呼ぶことで行う。
 
+#### 生成済み判定の on-memory cache
+
+generate エンドポイント内で同月生成済みかを確認する際、DB クエリ結果を on-memory（Ruby Hash）にキャッシュする。同一リクエスト内での重複クエリを避けるためのリクエストスコープキャッシュであり、プロセス間共有は不要。
+
+```ruby
+# Service 内でリクエストスコープの cache を持つ
+@generated_cache ||= {}  # "#{recurring_group_id}-#{year}-#{month}" => true
+```
+
 ### Entity
 
 `API::Entities::RecurringRecords::RecurringRecord` を新規作成。

--- a/docs/design-doc/0017-api-recurring-records.md
+++ b/docs/design-doc/0017-api-recurring-records.md
@@ -34,7 +34,6 @@ t_def.string  :encrypted_title,    null: false
 t_def.integer :amount,             null: false
 t_def.string  :category_id,        null: false
 t_def.string  :payment_method_id,  null: false
-t_def.integer :day_of_month,       null: false  # 毎月何日に生成するか (1-31, -1: 末日)
 t_def.string  :encrypted_description, null: true
 t_def.date    :start_date,         null: false  # 繰り返し開始月
 t_def.date    :end_date,           null: true   # 繰り返し終了月 (null: 無期限)
@@ -74,7 +73,6 @@ t_def.string :recurring_group_id, null: true  # recurring_records.id を参照
   "amount": 1980,
   "category_id": "cat_xxx",
   "payment_method_id": "pm_xxx",
-  "day_of_month": 1,
   "start_date": "2026-06-01",
   "end_date": null
 }
@@ -92,7 +90,6 @@ t_def.string :recurring_group_id, null: true  # recurring_records.id を参照
       "state": "確定",
       "category": "サブスク",
       "payment_method": "クレジットカード",
-      "day_of_month": 1,
       "start_date": "2026-06-01",
       "end_date": null,
       "record_type_id": 1,
@@ -141,7 +138,7 @@ GET /api/v1/records?recurring=true
 
 `request_userdata` が呼ばれた後（認証成功後）、`RecurringRecordGenerator` サービスを呼んで当月までの未生成分を生成する。処理はバックグラウンドではなく同期的に行う（件数が少ない前提）。
 
-生成済み判定: `finance_records` に同じ `recurring_group_id` かつ同月の日付のレコードが存在すれば生成済み。
+生成済み判定: `finance_records` に同じ `recurring_group_id` かつ同月（year + month が一致）のレコードが存在すれば生成済み。生成時の日付は月初（1日）で統一する。
 
 ### Entity
 
@@ -185,5 +182,4 @@ GET /api/v1/records?recurring=true
 
 ## 未解決事項
 
-- `day_of_month: 31` で存在しない月（2月など）への対応: 末日にフォールバックする
 - `end_date` を超えた recurring_record の扱い: 生成時にスキップするが、deleted_at を立てるかは今後判断

--- a/docs/design-doc/0017-api-recurring-records.md
+++ b/docs/design-doc/0017-api-recurring-records.md
@@ -140,11 +140,16 @@ GET /api/v1/records?recurring=true
 
 #### 生成済み判定の on-memory cache
 
-generate エンドポイント内で同月生成済みかを確認する際、DB クエリ結果を on-memory（Ruby Hash）にキャッシュする。同一リクエスト内での重複クエリを避けるためのリクエストスコープキャッシュであり、プロセス間共有は不要。
+generate エンドポイント内で同月生成済みかを確認する際、`ActiveSupport::Cache::MemoryStore` をプロセスグローバルなキャッシュとして使用する。月イチ程度の更新頻度なので TTL は 1 ヶ月に設定する。ActiveSupport はすでに ActiveRecord 経由で依存済みのため追加コストなし。
 
 ```ruby
-# Service 内でリクエストスコープの cache を持つ
-@generated_cache ||= {}  # "#{recurring_group_id}-#{year}-#{month}" => true
+RECURRING_CACHE = ActiveSupport::Cache::MemoryStore.new
+
+# 生成済み確認
+key = "#{hashed_user_id}-#{recurring_group_id}-#{year}-#{month}"
+RECURRING_CACHE.fetch(key, expires_in: 1.month) do
+  DB::Repository::FinanceRecord.exists_in_month?(recurring_group_id:, year:, month:)
+end
 ```
 
 ### Entity

--- a/docs/design-doc/0017-api-recurring-records.md
+++ b/docs/design-doc/0017-api-recurring-records.md
@@ -1,0 +1,189 @@
+# 0017 recurring records API
+
+> **scope**: api, db | **date**: 2026-06-14
+
+## 概要
+
+`recurring_records` テーブルを新設し、繰り返しレコードの定義を管理する。ログイン時に未生成月の `finance_records` を自動生成する仕組みと、手動で翌月分を生成するエンドポイントを追加する。また `finance_records` に `recurring_group_id` を追加して繰り返しグループと紐付ける。
+
+## 目標
+
+- `recurring_records` テーブルで繰り返し定義を CRUD できる
+- ログイン時に当月までの未生成分の `finance_records` を自動生成する
+- 手動で任意月の `finance_records` を生成するエンドポイントを持つ
+- `finance_records` の作成・更新時に `recurring_group_id` を指定できる
+- recurring フラグで絞り込む GET エンドポイントを追加する
+
+## 非目標
+
+- フロントエンド UI（別 ddoc で対応）
+- recurring_records のグループ単位一括編集（今回は定義の CRUD のみ）
+
+## 設計
+
+### データモデル
+
+**recurring_records テーブル（新規）**
+
+```ruby
+t_def.string  :id,                 null: false, primary_key: true
+t_def.string  :hashed_user_id,     null: false
+t_def.integer :record_type_id,     null: false
+t_def.integer :state_id,           null: false
+t_def.string  :encrypted_title,    null: false
+t_def.integer :amount,             null: false
+t_def.string  :category_id,        null: false
+t_def.string  :payment_method_id,  null: false
+t_def.integer :day_of_month,       null: false  # 毎月何日に生成するか (1-31, -1: 末日)
+t_def.string  :encrypted_description, null: true
+t_def.date    :start_date,         null: false  # 繰り返し開始月
+t_def.date    :end_date,           null: true   # 繰り返し終了月 (null: 無期限)
+t_def.datetime :deleted_at,        null: true
+t_def.timestamps null: false
+```
+
+インデックス: `hashed_user_id`, `category_id`, `payment_method_id`
+
+**finance_records テーブル（変更）**
+
+```ruby
+# 既存カラムに追加
+t_def.string :recurring_group_id, null: true  # recurring_records.id を参照
+```
+
+インデックス: `recurring_group_id`
+
+### API 設計
+
+#### recurring_records CRUD
+
+| メソッド | パス | 説明 |
+|---------|------|------|
+| GET | /api/v1/recurring_records | 繰り返し定義一覧取得 |
+| POST | /api/v1/recurring_records | 繰り返し定義作成 |
+| PUT | /api/v1/recurring_records/:id | 繰り返し定義更新 |
+| DELETE | /api/v1/recurring_records/:id | 繰り返し定義削除 |
+
+**POST /api/v1/recurring_records リクエスト:**
+```json
+{
+  "title": "Netflix",
+  "type_id": 1,
+  "state_id": 1,
+  "description": "",
+  "amount": 1980,
+  "category_id": "cat_xxx",
+  "payment_method_id": "pm_xxx",
+  "day_of_month": 1,
+  "start_date": "2026-06-01",
+  "end_date": null
+}
+```
+
+**GET /api/v1/recurring_records レスポンス:**
+```json
+{
+  "recurring_records": [
+    {
+      "id": "rr_xxx",
+      "title": "Netflix",
+      "type": "支出",
+      "amount": 1980,
+      "state": "確定",
+      "category": "サブスク",
+      "payment_method": "クレジットカード",
+      "day_of_month": 1,
+      "start_date": "2026-06-01",
+      "end_date": null,
+      "record_type_id": 1,
+      "state_id": 1,
+      "category_id": "cat_xxx",
+      "payment_method_id": "pm_xxx"
+    }
+  ]
+}
+```
+
+#### 月次生成エンドポイント
+
+| メソッド | パス | 説明 |
+|---------|------|------|
+| POST | /api/v1/recurring_records/generate | 指定月の finance_records を生成 |
+
+**リクエスト:**
+```json
+{
+  "year": 2026,
+  "month": 7
+}
+```
+
+**レスポンス:**
+```json
+{
+  "generated_count": 3,
+  "records": [{ "id": "fr_xxx", "status": "created" }]
+}
+```
+
+既に同 `recurring_group_id` + 同月のレコードが存在する場合はスキップ（冪等）。
+
+#### finance_records の変更
+
+- POST/PUT に `recurring_group_id` パラメータ（optional）を追加
+- GET に `recurring` フィルタパラメータを追加
+
+```
+GET /api/v1/records?recurring=true
+```
+
+#### ログイン時自動生成
+
+`request_userdata` が呼ばれた後（認証成功後）、`RecurringRecordGenerator` サービスを呼んで当月までの未生成分を生成する。処理はバックグラウンドではなく同期的に行う（件数が少ない前提）。
+
+生成済み判定: `finance_records` に同じ `recurring_group_id` かつ同月の日付のレコードが存在すれば生成済み。
+
+### Entity
+
+`API::Entities::RecurringRecords::RecurringRecord` を新規作成。
+
+## 変更ファイル一覧
+
+- `api/db/models.rb` — `RecurringRecord` モデル追加、`FinanceRecord` に `recurring_group_id` カラム追加
+- `api/db/repositories.rb` — `RecurringRecord` リポジトリ追加、`FinanceRecord` リポジトリに `recurring_group_id` フィルタ・`recurring` フィルタ追加
+- `api/services/recurring_records.rb` — 新規。RecurringRecord の CRUD サービス
+- `api/services/recurring_record_generator.rb` — 新規。月次生成ロジック（未生成月を検出して finance_records を生成）
+- `api/services/records.rb` — `create` / `update` に `recurring_group_id` パラメータ追加、`get_records` に `recurring` フィルタ追加
+- `api/app/api/v1/recurring_records.rb` — 新規。CRUD + generate エンドポイント
+- `api/app/api/v1/records.rb` — GET に `recurring` param 追加、POST/PUT に `recurring_group_id` param 追加
+- `api/app/api/v1/entities/recurring_records.rb` — 新規。`RecurringRecord` エンティティ
+- `api/app/api/v1/root.rb` — `RecurringRecords` を mount
+- `api/app/api/root.rb` — swagger の `models:` に `RecurringRecord` エンティティ追加
+- `api/spec/api/v1/recurring_records_spec.rb` — 新規。CRUD + generate の spec
+- `api/spec/api/v1/records_spec.rb` — `recurring_group_id` / `recurring` フィルタのテスト追加
+- `mysql/init.d/00_user_database.sql` — `recurring_records` テーブル DDL 追加、`finance_records` に `recurring_group_id` カラム追加
+
+## 実装ステップ
+
+1. `mysql/init.d/00_user_database.sql` に `recurring_records` テーブルと `finance_records.recurring_group_id` カラムを追加する
+2. `api/db/models.rb` に `RecurringRecord` モデルを追加し、`FinanceRecord` に `recurring_group_id` を追加する
+3. `api/db/repositories.rb` に `RecurringRecord` リポジトリを追加し、`FinanceRecord` リポジトリを更新する
+4. `api/services/recurring_records.rb` を新規作成（CRUD）
+5. `api/services/recurring_record_generator.rb` を新規作成（月次生成ロジック）
+6. `api/services/records.rb` を更新（`recurring_group_id` / `recurring` フィルタ対応）
+7. `api/app/api/v1/entities/recurring_records.rb` を新規作成
+8. `api/app/api/v1/recurring_records.rb` を新規作成（CRUD + generate エンドポイント）
+9. `api/app/api/v1/records.rb` を更新（パラメータ追加）
+10. `api/app/api/v1/root.rb` と `api/app/api/root.rb` を更新（mount / swagger 登録）
+11. `api/app/api/root.rb` の `request_userdata` ヘルパーにログイン時自動生成を追加
+12. spec を追加・更新してテストを通す
+
+## 代替案
+
+- **finance_records に recurring 定義を直接持たせる**: 現行の `recurring` boolean フラグがこれに相当する。グループ連動や自動生成ができないため今回は採用しない。
+- **バックグラウンドジョブ（Cron）で自動生成**: インフラ変更が必要で scope が大きくなるため、ログイン時生成を採用する。
+
+## 未解決事項
+
+- `day_of_month: 31` で存在しない月（2月など）への対応: 末日にフォールバックする
+- `end_date` を超えた recurring_record の扱い: 生成時にスキップするが、deleted_at を立てるかは今後判断

--- a/docs/design-doc/0017-api-recurring-records.md
+++ b/docs/design-doc/0017-api-recurring-records.md
@@ -4,15 +4,14 @@
 
 ## 概要
 
-`recurring_records` テーブルを新設し、繰り返しレコードの定義を管理する。ログイン時に未生成月の `finance_records` を自動生成する仕組みと、手動で翌月分を生成するエンドポイントを追加する。また `finance_records` に `recurring_group_id` を追加して繰り返しグループと紐付ける。
+`recurring_records` テーブルを新設し、繰り返しレコードの定義を管理する。指定月 + 指定 recurring_id で `finance_records` を生成するエンドポイントを追加する。また `finance_records` に `recurring_group_id` を追加して繰り返しグループと紐付ける。
 
 ## 目標
 
 - `recurring_records` テーブルで繰り返し定義を CRUD できる
-- ログイン時に当月までの未生成分の `finance_records` を自動生成する
-- 手動で任意月の `finance_records` を生成するエンドポイントを持つ
+- 指定月 + 指定 recurring_id で `finance_records` を生成するエンドポイントを持つ
 - `finance_records` の作成・更新時に `recurring_group_id` を指定できる
-- recurring フラグで絞り込む GET エンドポイントを追加する
+- `recurring_group_id` の有無で絞り込む GET エンドポイントを追加する
 
 ## 非目標
 
@@ -103,9 +102,11 @@ t_def.string :recurring_group_id, null: true  # recurring_records.id を参照
 
 #### 月次生成エンドポイント
 
+指定月 + 指定 recurring_id の組み合わせで `finance_records` を 1 件生成する。
+
 | メソッド | パス | 説明 |
 |---------|------|------|
-| POST | /api/v1/recurring_records/generate | 指定月の finance_records を生成 |
+| POST | /api/v1/recurring_records/:id/generate | 指定 recurring_id・指定月の finance_record を生成 |
 
 **リクエスト:**
 ```json
@@ -118,27 +119,23 @@ t_def.string :recurring_group_id, null: true  # recurring_records.id を参照
 **レスポンス:**
 ```json
 {
-  "generated_count": 3,
-  "records": [{ "id": "fr_xxx", "status": "created" }]
+  "status": "created",
+  "id": "fr_xxx"
 }
 ```
 
-既に同 `recurring_group_id` + 同月のレコードが存在する場合はスキップ（冪等）。
+既に同 `recurring_group_id` + 同月のレコードが存在する場合は HTTP 409 を返す（冪等ではなく明示的エラー）。
 
 #### finance_records の変更
 
 - POST/PUT に `recurring_group_id` パラメータ（optional）を追加
-- GET に `recurring` フィルタパラメータを追加
+- GET に `recurring` フィルタパラメータを追加（`recurring_group_id IS NOT NULL` で絞り込む）
 
 ```
 GET /api/v1/records?recurring=true
 ```
 
-#### ログイン時自動生成
-
-`request_userdata` が呼ばれた後（認証成功後）、`RecurringRecordGenerator` サービスを呼んで当月までの未生成分を生成する。処理はバックグラウンドではなく同期的に行う（件数が少ない前提）。
-
-生成済み判定: `finance_records` に同じ `recurring_group_id` かつ同月（year + month が一致）のレコードが存在すれば生成済み。生成時の日付は月初（1日）で統一する。
+ログイン時の自動生成は行わない。`finance_records` の生成は上記 generate エンドポイントを明示的に呼ぶことで行う。
 
 ### Entity
 
@@ -148,8 +145,7 @@ GET /api/v1/records?recurring=true
 
 - `api/db/models.rb` — `RecurringRecord` モデル追加、`FinanceRecord` に `recurring_group_id` カラム追加
 - `api/db/repositories.rb` — `RecurringRecord` リポジトリ追加、`FinanceRecord` リポジトリに `recurring_group_id` フィルタ・`recurring` フィルタ追加
-- `api/services/recurring_records.rb` — 新規。RecurringRecord の CRUD サービス
-- `api/services/recurring_record_generator.rb` — 新規。月次生成ロジック（未生成月を検出して finance_records を生成）
+- `api/services/recurring_records.rb` — 新規。RecurringRecord の CRUD + generate サービス
 - `api/services/records.rb` — `create` / `update` に `recurring_group_id` パラメータ追加、`get_records` に `recurring` フィルタ追加
 - `api/app/api/v1/recurring_records.rb` — 新規。CRUD + generate エンドポイント
 - `api/app/api/v1/records.rb` — GET に `recurring` param 追加、POST/PUT に `recurring_group_id` param 追加
@@ -165,15 +161,13 @@ GET /api/v1/records?recurring=true
 1. `mysql/init.d/00_user_database.sql` に `recurring_records` テーブルと `finance_records.recurring_group_id` カラムを追加する
 2. `api/db/models.rb` に `RecurringRecord` モデルを追加し、`FinanceRecord` に `recurring_group_id` を追加する
 3. `api/db/repositories.rb` に `RecurringRecord` リポジトリを追加し、`FinanceRecord` リポジトリを更新する
-4. `api/services/recurring_records.rb` を新規作成（CRUD）
-5. `api/services/recurring_record_generator.rb` を新規作成（月次生成ロジック）
-6. `api/services/records.rb` を更新（`recurring_group_id` / `recurring` フィルタ対応）
+4. `api/services/recurring_records.rb` を新規作成（CRUD + generate ロジック）
+5. `api/services/records.rb` を更新（`recurring_group_id` / `recurring` フィルタ対応）
 7. `api/app/api/v1/entities/recurring_records.rb` を新規作成
-8. `api/app/api/v1/recurring_records.rb` を新規作成（CRUD + generate エンドポイント）
-9. `api/app/api/v1/records.rb` を更新（パラメータ追加）
-10. `api/app/api/v1/root.rb` と `api/app/api/root.rb` を更新（mount / swagger 登録）
-11. `api/app/api/root.rb` の `request_userdata` ヘルパーにログイン時自動生成を追加
-12. spec を追加・更新してテストを通す
+7. `api/app/api/v1/recurring_records.rb` を新規作成（CRUD + generate エンドポイント）
+8. `api/app/api/v1/records.rb` を更新（パラメータ追加）
+9. `api/app/api/v1/root.rb` と `api/app/api/root.rb` を更新（mount / swagger 登録）
+10. spec を追加・更新してテストを通す
 
 ## 代替案
 

--- a/docs/design-doc/0018-front-recurring-records.md
+++ b/docs/design-doc/0018-front-recurring-records.md
@@ -1,0 +1,96 @@
+# 0018 recurring records frontend
+
+> **scope**: front | **date**: 2026-06-14
+
+## 概要
+
+明細テーブルに recurring バッジを追加し、新規作成フォームで recurring フラグと `recurring_group_id` を指定できるようにする。また recurring レコードのみ絞り込むフィルタ UI を追加する。
+
+## 目標
+
+- 明細テーブルの各行に recurring バッジを表示する
+- 新規作成フォームで recurring フラグを ON/OFF できる
+- 新規作成フォームで `recurring_group_id`（繰り返し定義）を選択できる
+- recurring フラグでレコードを絞り込むフィルタ UI を追加する
+
+## 非目標
+
+- recurring records 専用ページ（エンドポイントが整備され次第、別途実装）
+- 既存レコードのインライン編集（現状テーブルは閲覧のみ）
+
+## 前提
+
+ddoc 0017 の API が実装済みであること。具体的には以下が利用可能であること。
+- `GET /api/v1/records?recurring=true` — recurring フィルタ
+- `GET /api/v1/recurring_records` — 繰り返し定義一覧
+- `POST /api/v1/records` に `recurring_group_id` パラメータが追加済み
+
+## 設計
+
+### コンポーネント構成
+
+既存の `ExpenseDetails.svelte` を修正する。新規コンポーネントは作らない。
+
+**変更内容:**
+
+1. **recurring バッジ**: 各行の用途列（`layout-title`）の横、または先頭チェックボックス列の隣にバッジを表示する。`record.recurring === true` の場合のみ表示する。
+   - バッジテキスト: 「定期」
+   - スタイル: 小さいラベル、primary カラーの枠線
+
+2. **新規作成フォーム — recurring チェックボックス**: テーブル末尾の新規入力行に recurring チェックボックスを追加する。列は既存の末尾（追加ボタン列の手前）に挿入する。
+
+3. **新規作成フォーム — recurring_group_id セレクト**: recurring チェックボックスが ON の場合のみ表示するセレクトを追加する。繰り返し定義一覧（`GET /api/v1/recurring_records`）から選択肢を生成する。
+
+4. **recurring フィルタ**: テーブルヘッダー上部に「定期のみ表示」トグルを追加する。ON の場合、`GET /api/v1/records` に `recurring=true` を付与して再取得する。
+
+### 状態管理
+
+`ExpenseDetails.svelte` に以下の状態を追加する。
+
+```typescript
+let newRecurring = $state<boolean>(false);
+let newRecurringGroupId = $state<string | undefined>(undefined);
+let recurringRecords = $state<RecurringRecord[]>([]);
+let filterRecurring = $state<boolean>(false);
+```
+
+`onMount` 時に `api.fetchRecurringRecords()` で繰り返し定義一覧を取得する。
+
+`filterRecurring` が変化したとき（`$effect`）、`loadRecords` に `recurring` フィルタを渡す。
+
+### API クライアント変更
+
+- `front/src/lib/api/v1/types.d.ts` — `RecurringRecord` 型、`RecurringRecordsResponse` 型、`CreateRecordRequest` / `UpdateRecordRequest` に `recurring_group_id?: string` を追加
+- `front/src/lib/api/v1/api.ts` — `fetchRecurringRecords()` 関数を追加、`fetchRecords` に `recurring` オプションパラメータを追加
+
+### UI イメージ
+
+```
+[ 定期のみ表示 □ ]
+
+| □ | 日付 | 種別 | 金額 | カテゴリ | 支払方法 | 状態 | 用途         |   |
+|---|------|------|------|----------|----------|------|--------------|---|
+| □ | 6/1  | 支出 | ¥1,980 | サブスク | クレジット | 確定 | Netflix [定期] |   |
+| □ | 6/15 | 支出 | ¥500 | 食費     | 現金      | 確定 | コーヒー      |   |
+| □ |新規入力行... | [□定期] [定義選択▼] | [追加] |
+```
+
+## 変更ファイル一覧
+
+- `front/src/lib/api/v1/types.d.ts` — `RecurringRecord`, `RecurringRecordsResponse` 型追加、`CreateRecordRequest` / `UpdateRecordRequest` に `recurring_group_id?: string` 追加、`fetchRecords` の引数型に `recurring?: boolean` 追加
+- `front/src/lib/api/v1/api.ts` — `fetchRecurringRecords()` 追加、`fetchRecords` に `recurring` パラメータ追加
+- `front/src/lib/components/ExpenseDetails.svelte` — recurring バッジ、フォームの recurring チェックボックス + recurring_group_id セレクト、filterRecurring トグル追加
+
+## 実装ステップ
+
+1. `types.d.ts` に `RecurringRecord` / `RecurringRecordsResponse` 型を追加し、既存リクエスト型に `recurring_group_id` を追加する
+2. `api.ts` に `fetchRecurringRecords()` を追加し、`fetchRecords` に `recurring` フィルタを追加する
+3. `ExpenseDetails.svelte` に `filterRecurring` トグルと `loadRecords` への反映を追加する
+4. `ExpenseDetails.svelte` の各行に recurring バッジを追加する（表示のみ）
+5. `ExpenseDetails.svelte` の新規入力行に recurring チェックボックスと recurring_group_id セレクトを追加し、`handleCreate` に反映する
+6. `pnpm svelte-check` / `pnpm eslint` / `pnpm lint:style` をパスさせる
+
+## 未解決事項
+
+- recurring_group_id セレクトに「なし」オプションを含めるかどうか（recurring=true でも group 未指定を許容するか）
+- バッジの配置列（用途列内に inline で置くか、専用列を追加するか）

--- a/docs/design-doc/0018-front-recurring-records.md
+++ b/docs/design-doc/0018-front-recurring-records.md
@@ -4,19 +4,20 @@
 
 ## 概要
 
-明細テーブルに recurring バッジを追加し、新規作成フォームで recurring フラグと `recurring_group_id` を指定できるようにする。また recurring レコードのみ絞り込むフィルタ UI を追加する。
+明細テーブルに recurring アイコンを追加し、新規作成フォームで `recurring_group_id` を指定できるようにする。recurring_records を操作する専用テーブルコンポーネントと作成・編集フォームを追加する。また recurring レコードのみ絞り込むフィルタ UI を追加する。
 
 ## 目標
 
-- 明細テーブルの各行に recurring バッジを表示する
-- 新規作成フォームで recurring フラグを ON/OFF できる
+- 明細テーブルの各行に `recurring_group_id` を持つレコードへ repeat アイコンを表示する
 - 新規作成フォームで `recurring_group_id`（繰り返し定義）を選択できる
+- `recurring_group_id` を持つ finance_records のインライン編集ができる
+- recurring_records を操作する専用テーブルコンポーネントを追加する（CRUD + generate）
+- recurring_records の作成・編集に使う専用フォームコンポーネントを追加する
 - recurring フラグでレコードを絞り込むフィルタ UI を追加する
 
 ## 非目標
 
-- recurring records 専用ページ（エンドポイントが整備され次第、別途実装）
-- 既存レコードのインライン編集（現状テーブルは閲覧のみ）
+- recurring records 専用ページ（コンポーネントを用意するが、ルーティングは今後）
 
 ## 前提
 
@@ -29,17 +30,19 @@ ddoc 0017 の API が実装済みであること。具体的には以下が利�
 
 ### コンポーネント構成
 
-既存の `ExpenseDetails.svelte` を修正する。新規コンポーネントは作らない。
+**新規コンポーネント:**
 
-**変更内容:**
+- `RecurringRecordForm.svelte` — recurring_record の作成・編集フォーム。作成時は POST、編集時は PUT を呼ぶ。同じフォームを両用する。
+- `RecurringRecordsTable.svelte` — recurring_records の一覧テーブル。各行に編集・削除ボタンと「この月分を生成」ボタンを持つ。
 
-1. **recurring バッジ**: 各行の用途列（`layout-title`）の横、または先頭チェックボックス列の隣にバッジを表示する。`record.recurring === true` の場合のみ表示する。
-   - バッジテキスト: 「定期」
-   - スタイル: 小さいラベル、primary カラーの枠線
+**既存コンポーネントの変更（`ExpenseDetails.svelte`）:**
 
-2. **新規作成フォーム — recurring チェックボックス**: テーブル末尾の新規入力行に recurring チェックボックスを追加する。列は既存の末尾（追加ボタン列の手前）に挿入する。
+1. **repeat アイコン**: `recurring_group_id` を持つ行の用途列（`layout-title`）に Font Awesome の repeat アイコン（`fa-rotate` 等）を表示する。
+   - アイコンは `@fortawesome/free-solid-svg-icons` から取得する。未導入の場合は SVG インライン or Unicode 代替（↻）で対応する。
 
-3. **新規作成フォーム — recurring_group_id セレクト**: recurring チェックボックスが ON の場合のみ表示するセレクトを追加する。繰り返し定義一覧（`GET /api/v1/recurring_records`）から選択肢を生成する。
+2. **新規作成フォーム — recurring_group_id セレクト**: テーブル末尾の新規入力行に recurring_group_id セレクトを追加する。「なし」オプションを先頭に置き、繰り返し定義一覧（`GET /api/v1/recurring_records`）から選択肢を生成する。
+
+3. **インライン編集**: `recurring_group_id` を持つ行も通常行と同じインライン編集が可能。`PUT /api/v1/records/:id` に `recurring_group_id` を含めて送信する。
 
 4. **recurring フィルタ**: テーブルヘッダー上部に「定期のみ表示」トグルを追加する。ON の場合、`GET /api/v1/records` に `recurring=true` を付与して再取得する。
 
@@ -48,7 +51,6 @@ ddoc 0017 の API が実装済みであること。具体的には以下が利�
 `ExpenseDetails.svelte` に以下の状態を追加する。
 
 ```typescript
-let newRecurring = $state<boolean>(false);
 let newRecurringGroupId = $state<string | undefined>(undefined);
 let recurringRecords = $state<RecurringRecord[]>([]);
 let filterRecurring = $state<boolean>(false);
@@ -65,32 +67,45 @@ let filterRecurring = $state<boolean>(false);
 
 ### UI イメージ
 
+**ExpenseDetails（明細テーブル）:**
 ```
 [ 定期のみ表示 □ ]
 
-| □ | 日付 | 種別 | 金額 | カテゴリ | 支払方法 | 状態 | 用途         |   |
-|---|------|------|------|----------|----------|------|--------------|---|
-| □ | 6/1  | 支出 | ¥1,980 | サブスク | クレジット | 確定 | Netflix [定期] |   |
-| □ | 6/15 | 支出 | ¥500 | 食費     | 現金      | 確定 | コーヒー      |   |
-| □ |新規入力行... | [□定期] [定義選択▼] | [追加] |
+| □ | 日付 | 種別 | 金額 | カテゴリ | 支払方法 | 状態 | 用途            |   |
+|---|------|------|------|----------|----------|------|-----------------|---|
+| □ | 6/1  | 支出 | ¥1,980 | サブスク | クレジット | 確定 | ↻ Netflix     |   |
+| □ | 6/15 | 支出 | ¥500 | 食費     | 現金      | 確定 | コーヒー         |   |
+| □ | 新規入力行... | [定義選択▼] | [追加] |
+```
+
+**RecurringRecordsTable:**
+```
+| タイトル  | 金額   | カテゴリ | 開始月   |          |
+|---------|--------|----------|---------|----------|
+| Netflix | ¥1,980 | サブスク  | 2026/06 | [編集][削除][今月分生成] |
+| 新規作成行 → RecurringRecordForm を表示 |
 ```
 
 ## 変更ファイル一覧
 
-- `front/src/lib/api/v1/types.d.ts` — `RecurringRecord`, `RecurringRecordsResponse` 型追加、`CreateRecordRequest` / `UpdateRecordRequest` に `recurring_group_id?: string` 追加、`fetchRecords` の引数型に `recurring?: boolean` 追加
-- `front/src/lib/api/v1/api.ts` — `fetchRecurringRecords()` 追加、`fetchRecords` に `recurring` パラメータ追加
-- `front/src/lib/components/ExpenseDetails.svelte` — recurring バッジ、フォームの recurring チェックボックス + recurring_group_id セレクト、filterRecurring トグル追加
+- `front/src/lib/api/v1/types.d.ts` — `RecurringRecord`, `RecurringRecordsResponse`, `CreateRecurringRecordRequest`, `UpdateRecurringRecordRequest`, `GenerateRecurringRecordRequest` 型追加、`CreateRecordRequest` / `UpdateRecordRequest` に `recurring_group_id?: string` 追加
+- `front/src/lib/api/v1/api.ts` — `fetchRecurringRecords()`, `createRecurringRecord()`, `updateRecurringRecord()`, `deleteRecurringRecord()`, `generateRecurringRecord()` 追加、`fetchRecords` に `recurring` パラメータ追加
+- `front/src/lib/components/RecurringRecordForm.svelte` — 新規。recurring_record の作成・編集フォーム
+- `front/src/lib/components/RecurringRecordsTable.svelte` — 新規。recurring_records の一覧テーブル（CRUD + generate）
+- `front/src/lib/components/index.ts` — 上記 2 コンポーネントをエクスポート追加
+- `front/src/lib/components/ExpenseDetails.svelte` — repeat アイコン表示、recurring_group_id セレクト、インライン編集対応、filterRecurring トグル追加
 
 ## 実装ステップ
 
-1. `types.d.ts` に `RecurringRecord` / `RecurringRecordsResponse` 型を追加し、既存リクエスト型に `recurring_group_id` を追加する
-2. `api.ts` に `fetchRecurringRecords()` を追加し、`fetchRecords` に `recurring` フィルタを追加する
-3. `ExpenseDetails.svelte` に `filterRecurring` トグルと `loadRecords` への反映を追加する
-4. `ExpenseDetails.svelte` の各行に recurring バッジを追加する（表示のみ）
-5. `ExpenseDetails.svelte` の新規入力行に recurring チェックボックスと recurring_group_id セレクトを追加し、`handleCreate` に反映する
-6. `pnpm svelte-check` / `pnpm eslint` / `pnpm lint:style` をパスさせる
+1. `types.d.ts` に RecurringRecord 関連の型を追加する
+2. `api.ts` に RecurringRecord 関連の API 関数を追加し、`fetchRecords` に `recurring` フィルタを追加する
+3. `RecurringRecordForm.svelte` を新規作成する（作成・編集の両モードに対応）
+4. `RecurringRecordsTable.svelte` を新規作成する（CRUD + generate ボタン）
+5. `index.ts` に新規コンポーネントをエクスポート追加する
+6. `ExpenseDetails.svelte` を更新する（アイコン表示、recurring_group_id セレクト、インライン編集、フィルタ）
+7. `pnpm svelte-check` / `pnpm eslint` / `pnpm lint:style` をパスさせる
 
 ## 未解決事項
 
-- recurring_group_id セレクトに「なし」オプションを含めるかどうか（recurring=true でも group 未指定を許容するか）
-- バッジの配置列（用途列内に inline で置くか、専用列を追加するか）
+- Font Awesome が未導入の場合のアイコン代替手段（SVG インライン or Unicode ↻）
+- インライン編集の UX（編集モードへの切り替えトリガー — 行クリックかボタンか）


### PR DESCRIPTION
# What

issue #59（recurring 属性の付与）の実装に向けた Design Doc を追加する。

# Changes

- (docs): 0017 - recurring records API 設計（DB スキーマ変更、CRUD エンドポイント、自動生成ロジック）
- (docs): 0018 - recurring records フロントエンド設計（バッジ表示、フォーム入力、フィルタ UI）